### PR TITLE
Additional changes to make github actions happy.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,14 +9,13 @@ on:
       - pytest.ini
       - requirements-dev.txt
       - .github/workflows/pythonpackage.yml
-  workflow_dispatch:
 
 jobs:
   build-and-test:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
         platform: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,13 +9,14 @@ on:
       - pytest.ini
       - requirements-dev.txt
       - .github/workflows/pythonpackage.yml
+  workflow_dispatch:
 
 jobs:
   build-and-test:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
         platform: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,7 @@ jobs:
     - name: 🛠 Build Hexhamming Python C extension
       run: python setup.py install
     - name: Test with pytest
-      run: pytest
+      run: pytest -s .
   build-wheels:
     needs: build-and-test
     if: startsWith(github.ref, 'refs/tags')

--- a/hexhamming/python_hexhamming.cc
+++ b/hexhamming/python_hexhamming.cc
@@ -16,6 +16,8 @@
 //Pointers to functions. Will be inited in PyMODINIT_FUNC by USE__* macros(can be found at end of header file).
 static int (*ptr__hamming_distance_bytes)(const uint8_t*, const uint8_t*, const size_t, const ssize_t);
 static int (*ptr__hamming_distance_string)(const char*, const char*, const size_t);
+//Bit mask off CPU capabilities.
+static int cpu_capabilities;
 
 
 /**
@@ -174,7 +176,7 @@ static PyObject * hamming_distance_byte_wrapper(PyObject *self, PyObject *args) 
  * @param args      Python arguments for `check_hexstrings_within_dist` interface
  *                  - `string1` -- hex string
  *                  - `string2` -- hex string
- * @returns         
+ * @returns
  */
 static PyObject * check_hexstrings_within_dist_wrapper(PyObject *self, PyObject *args) {
     char *input_s1;
@@ -310,26 +312,38 @@ static PyObject * set_algo_wrapper(PyObject *self, PyObject *args) {
         return NULL;
     }
 
+    const char *result = "";
     if (strcmp(algo_name, "extra") == 0) {
-        USE__EXTRA
+        if ((cpu_capabilities & bit_AVX2) == bit_AVX2) {
+            USE__EXTRA
+        }
+        else
+            result = "CPU doesnt support this feature.";
     }
 #if defined(HAVE_NATIVE_POPCNT)
     else if (strcmp(algo_name, "native") == 0) {
-        USE__NATIVE
+        if ((cpu_capabilities & bit_POPCNT) == bit_POPCNT) {
+            USE__NATIVE
+        }
+        else
+            result = "CPU doesnt support this feature.";
     }
 #endif
 #if defined(CPU_X86_64)
     else if (strcmp(algo_name, "sse41") == 0) {
-        USE__SSE41
+        if ((cpu_capabilities & bit_SSE41) == bit_SSE41) {
+            USE__SSE41
+        }
+        else
+            result = "CPU doesnt support this feature.";
     }
 #endif
     else if (strcmp(algo_name, "classic") == 0) {
         USE__CLASSIC
     }
-    else {
-        return Py_BuildValue("s", "non supported algorithm.");
-    }
-    return Py_BuildValue("s", "");
+    else
+        result = "Library was built without this algorithm.";
+    return Py_BuildValue("s", result);
 }
 
 ///////////////////////////////////////////////////////////////
@@ -441,7 +455,7 @@ inithexhamming(void)
 
 {
      #if defined(CPU_X86_64)
-        int cpu_capabilities = get_cpuid();
+        cpu_capabilities = get_cpuid();
         if ((cpu_capabilities & bit_AVX2) == bit_AVX2) {
             USE__EXTRA
         }
@@ -458,6 +472,7 @@ inithexhamming(void)
         }
      #else
         #if defined(HAVE_NATIVE_POPCNT)
+            cpu_capabilities = bit_POPCNT;
             USE__NATIVE
         #else
             USE__CLASSIC

--- a/hexhamming/python_hexhamming.cc
+++ b/hexhamming/python_hexhamming.cc
@@ -16,8 +16,8 @@
 //Pointers to functions. Will be inited in PyMODINIT_FUNC by USE__* macros(can be found at end of header file).
 static int (*ptr__hamming_distance_bytes)(const uint8_t*, const uint8_t*, const size_t, const ssize_t);
 static int (*ptr__hamming_distance_string)(const char*, const char*, const size_t);
-//Bit mask off CPU capabilities.
-static int cpu_capabilities;
+static int cpu_capabilities;            //Bit mask off CPU capabilities.
+char cpu_not_support_msg[64];           //"CPU doesnt support this feature. %X" , cpu_capabilities
 
 
 /**
@@ -318,7 +318,7 @@ static PyObject * set_algo_wrapper(PyObject *self, PyObject *args) {
             USE__EXTRA
         }
         else
-            result = "CPU doesnt support this feature.";
+            result = cpu_not_support_msg;
     }
 #if defined(HAVE_NATIVE_POPCNT)
     else if (strcmp(algo_name, "native") == 0) {
@@ -326,7 +326,7 @@ static PyObject * set_algo_wrapper(PyObject *self, PyObject *args) {
             USE__NATIVE
         }
         else
-            result = "CPU doesnt support this feature.";
+            result = cpu_not_support_msg;
     }
 #endif
 #if defined(CPU_X86_64)
@@ -335,7 +335,7 @@ static PyObject * set_algo_wrapper(PyObject *self, PyObject *args) {
             USE__SSE41
         }
         else
-            result = "CPU doesnt support this feature.";
+            result = cpu_not_support_msg;
     }
 #endif
     else if (strcmp(algo_name, "classic") == 0) {
@@ -478,6 +478,7 @@ inithexhamming(void)
             USE__CLASSIC
         #endif
      #endif
+     snprintf(cpu_not_support_msg, sizeof(cpu_not_support_msg), "CPU doesnt support this feature. %X", cpu_capabilities);
 #if PY_MAJOR_VERSION >= 3
     PyObject *module = PyModule_Create(&hexhammingdef);
 #else

--- a/test/test_hexhamming.py
+++ b/test/test_hexhamming.py
@@ -68,9 +68,9 @@ def test_hamming_distance_byte(hex1, hex2, expected):
     algorithm_list = ['extra', 'native', 'sse41', 'classic']
     for algorithm in algorithm_list:
         result = set_algo(algorithm)
-        if result.startswith("CPU doesnt support this feature."):
+        if len(result) > 0:
+            print(f'Warning: Skipping {algorithm}, reason: {result}')
             continue
-        assert len(result) == 0
         assert expected == hamming_distance_bytes(hex1, hex2)
 
 
@@ -110,9 +110,9 @@ def test_check_hexstrings_within_dist(hex1, hex2, max_dist, expected):
     algorithm_list = ['extra', 'native', 'sse41', 'classic']
     for algorithm in algorithm_list:
         result = set_algo(algorithm)
-        if result.startswith("CPU doesnt support this feature."):
+        if len(result) > 0:
+            print(f'Warning: Skipping {algorithm}, reason: {result}')
             continue
-        assert len(result) == 0
         assert expected == check_hexstrings_within_dist(hex1, hex2, max_dist)
 
 
@@ -203,9 +203,9 @@ def test_check_bytes_arrays_within_dist_calculation(bytes1, bytes2, max_dist, ex
     algorithm_list = ['extra', 'native', 'sse41', 'classic']
     for algorithm in algorithm_list:
         result = set_algo(algorithm)
-        if result.startswith("CPU doesnt support this feature."):
+        if len(result) > 0:
+            print(f'Warning: Skipping {algorithm}, reason: {result}')
             continue
-        assert len(result) == 0
         assert expected == check_bytes_arrays_within_dist(bytes1, bytes2, max_dist)
 
 

--- a/test/test_hexhamming.py
+++ b/test/test_hexhamming.py
@@ -67,7 +67,10 @@ def test_hamming_distance_string(hex1, hex2, expected):
 def test_hamming_distance_byte(hex1, hex2, expected):
     algorithm_list = ['extra', 'native', 'sse41', 'classic']
     for algorithm in algorithm_list:
-        assert len(set_algo(algorithm)) == 0
+        result = set_algo(algorithm)
+        if result == "CPU doesnt support this feature.":
+            continue
+        assert len(result) == 0
         assert expected == hamming_distance_bytes(hex1, hex2)
 
 
@@ -106,7 +109,10 @@ def test_hamming_distance_string_errors(hex1, hex2, exception, msg):
 def test_check_hexstrings_within_dist(hex1, hex2, max_dist, expected):
     algorithm_list = ['extra', 'native', 'sse41', 'classic']
     for algorithm in algorithm_list:
-        assert len(set_algo(algorithm)) == 0
+        result = set_algo(algorithm)
+        if result == "CPU doesnt support this feature.":
+            continue
+        assert len(result) == 0
         assert expected == check_hexstrings_within_dist(hex1, hex2, max_dist)
 
 
@@ -196,7 +202,10 @@ def test_check_bytes_arrays_within_dist_invalid_values(bytes1, bytes2, max_dist,
 def test_check_bytes_arrays_within_dist_calculation(bytes1, bytes2, max_dist, expected):
     algorithm_list = ['extra', 'native', 'sse41', 'classic']
     for algorithm in algorithm_list:
-        assert len(set_algo(algorithm)) == 0
+        result = set_algo(algorithm)
+        if result == "CPU doesnt support this feature.":
+            continue
+        assert len(result) == 0
         assert expected == check_bytes_arrays_within_dist(bytes1, bytes2, max_dist)
 
 

--- a/test/test_hexhamming.py
+++ b/test/test_hexhamming.py
@@ -68,7 +68,7 @@ def test_hamming_distance_byte(hex1, hex2, expected):
     algorithm_list = ['extra', 'native', 'sse41', 'classic']
     for algorithm in algorithm_list:
         result = set_algo(algorithm)
-        if result == "CPU doesnt support this feature.":
+        if result.startswith("CPU doesnt support this feature."):
             continue
         assert len(result) == 0
         assert expected == hamming_distance_bytes(hex1, hex2)
@@ -110,7 +110,7 @@ def test_check_hexstrings_within_dist(hex1, hex2, max_dist, expected):
     algorithm_list = ['extra', 'native', 'sse41', 'classic']
     for algorithm in algorithm_list:
         result = set_algo(algorithm)
-        if result == "CPU doesnt support this feature.":
+        if result.startswith("CPU doesnt support this feature."):
             continue
         assert len(result) == 0
         assert expected == check_hexstrings_within_dist(hex1, hex2, max_dist)
@@ -203,7 +203,7 @@ def test_check_bytes_arrays_within_dist_calculation(bytes1, bytes2, max_dist, ex
     algorithm_list = ['extra', 'native', 'sse41', 'classic']
     for algorithm in algorithm_list:
         result = set_algo(algorithm)
-        if result == "CPU doesnt support this feature.":
+        if result.startswith("CPU doesnt support this feature."):
             continue
         assert len(result) == 0
         assert expected == check_bytes_arrays_within_dist(bytes1, bytes2, max_dist)


### PR DESCRIPTION
1. Added `-s` parameter to pytest, to see output of tests.
2. In tests added this output: `print(f'Warning: Skipping {algorithm}, reason: {result}')` 
3. `set_algo` now checks if cpu can run those algorithm.

P.S.:
On GitHub MacOS `sysctl -a | grep machdep.cpu.features` reports that AVX is present(`avx1.0`) but `cpuid` reports that `avx2.0` is not. So now set_algo checks for cpu capabilities and tests for `extra` on MacOS are currently skipped. It's fine with this.

