### PR TITLE
2.2.3 , Illegal Instruction fixed.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -208,4 +208,4 @@ jobs:
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload --skip-existing wheelhouse/*.whl
+      run: twine upload --skip-existing wheelhouse/*

--- a/hexhamming/_version.h
+++ b/hexhamming/_version.h
@@ -1,1 +1,1 @@
-const char _version[] = "2.2.2";
+const char _version[] = "2.2.3";

--- a/hexhamming/python_hexhamming.cc
+++ b/hexhamming/python_hexhamming.cc
@@ -476,12 +476,7 @@ inithexhamming(void)
         #endif
         USE__EXTRA
      #endif
-     if (cpu_capabilities != 0) {
-        snprintf(cpu_not_support_msg, sizeof(cpu_not_support_msg),
-                    "CPU doesnt support this feature. {%X}", cpu_capabilities);
-     }
-     else
-        snprintf(cpu_not_support_msg, sizeof(cpu_not_support_msg), "CPU doesnt support this feature.");
+     snprintf(cpu_not_support_msg, sizeof(cpu_not_support_msg), "CPU doesnt support this feature. {%X}", cpu_capabilities);
 #if PY_MAJOR_VERSION >= 3
     PyObject *module = PyModule_Create(&hexhammingdef);
 #else

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ if system().lower() == "darwin" and (machine().lower() == "arm64" or
     extra_compile_args.append("-mcpu=apple-m1")
 elif uname().system == 'Windows':
     extra_compile_args.append("-O2")
+    extra_compile_args.append("/d2FH4-")
 else:
     extra_compile_args.append("-march=native")
 


### PR DESCRIPTION
- Changed version to 2.2.3
- Add sdist upload to pypi.
- Fixed Illegal Instruction.

P.S:
We can't add O2 flag to Linux builds, because then  he  automaticly replaces SSE with AVX.
We cant use snprintf without args on Linux, because for some reason g++ replace it with SSE instructions.
