### PR TITLE
Array api

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,67 @@ You use it in the exact same way as before, except you pass in a byte string.
     >>> hamming_distance_bytes(b"\xde\xad\xbe\xef", b"\x00\x00\x00\x00")
     24
 
+
+We also provide a method for a quick boolean check of whether two hexadecimal strings
+are within a given Hamming distance.
+::
+    >>> from hexhamming import check_hexstrings_within_dist
+    >>> check_hexstrings_within_dist("ffff", "fffe", 2)
+    True
+    >>> check_hexstrings_within_dist("ffff", "0000", 2)
+    False
+	
+Similarly, ``hexhamming`` supports a quick byte array check via ``check_bytes_within_dist``, which has
+a similar API as ``check_hexstrings_within_dist``, except it expects a byte array. 
+
+The API described above is targeted at comparing two individual records and calculate their hamming distance quickly.
+For many applications the goal is compare a given record to an array of other records and to find out if there 
+are elements in the array that are within a given hamming distance of the search record. To support these application
+cases ``hexhamming`` has a set of array APIs. Given that these operations are often speed critical and require preparing data
+anyway, they are only available for bytes strings, not for hex strings.
+
+They all have the same signature, they take two bytes arrays and the ``max_dist`` to consider. The difference is, that the first
+bytes string should be a concatenation of a number of records to compare to, i.e. the length needs to be a multiple of the length
+of the second bytes string.
+
+There are three functions that return different results, depending on what is needed by the application.
+
+``check_bytes_arrays_first_within_dist`` returns the index of the first element that has a hamming distance less than ``max_dist``.
+
+::
+
+    >>> from hexhamming import check_bytes_arrays_first_within_dist
+    >>> check_bytes_arrays_first_within_dist(b"\xaa\xaa\xbb\xbb\xcc\xcc\xdd\xdd\xee\xee\xff\xff", b"\xff\xff", 4)
+    1
+
+
+``check_bytes_arrays_best_within_dist`` returns a tuple with the distance and the index of the element that has the lowest hamming 
+distance less than ``max_dist``, or ``(-1,-1)`` if none do.
+
+::
+
+    >>> from hexhamming import check_bytes_arrays_best_within_dist
+    >>> check_bytes_arrays_best_within_dist(b"\xaa\xaa\xbb\xbb\xcc\xcc\xdd\xdd\xee\xee\xff\xff", b"\xff\xff", 4)
+    (0, 5)
+	
+	>>> check_bytes_arrays_best_within_dist(b"\xaa\xaa\xbb\xbb\xcc\xcc\xdd\xdd\xee\xee\xff\xff", b"\xef\xfe", 4)	
+	(2, 4)
+
+
+``check_bytes_arrays_all_within_dist`` returns a  list of tuples with the distance and the index of the element that have a hamming 
+distance less than ``max_dist``, or ``[])`` if none do.
+
+::
+
+    >>> from hexhamming import check_bytes_arrays_all_within_dist
+    >>> check_bytes_arrays_all_within_dist(b"\xaa\xaa\xbb\xbb\xcc\xcc\xdd\xdd\xee\xee\xff\xff", b"\xff\xff", 4)
+    [(4, 1), (4, 3), (4, 4), (0, 5)]
+
+
+Tip: When you're assembling the long array of records to compare against, don't concatenate the different ``bytes`` together. As they're
+immutable that is a very slow operation. Use a ``bytearray`` instead, and cast it to ``bytes`` at the end. See https://www.guyrutenberg.com/2020/04/04/fast-bytes-concatenation-in-python/ for more info and tests.
+
+
 Benchmark
 ---------
 

--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ are within a given Hamming distance.
     False
 	
 Similarly, ``hexhamming`` supports a quick byte array check via ``check_bytes_within_dist``, which has
-a similar API as ``check_hexstrings_within_dist``, except it expects a byte array. 
+a similar API as ``check_hexstrings_within_dist``, except it expects a bytes array. 
 
 The API described above is targeted at comparing two individual records and calculate their hamming distance quickly.
 For many applications the goal is compare a given record to an array of other records and to find out if there 

--- a/hexhamming/_version.h
+++ b/hexhamming/_version.h
@@ -1,1 +1,1 @@
-const char _version[] = "2.2.3";
+const char _version[] = "2.2.3.1";

--- a/hexhamming/python_hexhamming.cc
+++ b/hexhamming/python_hexhamming.cc
@@ -271,9 +271,9 @@ static PyObject * check_bytes_within_dist_wrapper(PyObject *self, PyObject *args
         PyErr_SetString(PyExc_ValueError, "array sizes need to be the same");
         return NULL;
     }
-
-	int64_t result;
-	result = ptr__hamming_distance_bytes(array_1, array_2, array_2_size, max_dist);
+    
+    int64_t result;
+    result = ptr__hamming_distance_bytes(array_1, array_2, array_2_size, max_dist);
 		
     return Py_BuildValue("O", result == 1 ? Py_True : Py_False);
 }
@@ -319,21 +319,20 @@ static PyObject * check_bytes_arrays_first_within_dist_wrapper(PyObject *self, P
 
     int64_t ret = -1;
 	
-	Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS
 	
     uint64_t number_of_elements = big_array_size / small_array_size;
     uint8_t* pBig = big_array;
 	uint64_t res;
     for (uint64_t i = 0; i < number_of_elements; i++, pBig += small_array_size) {
         res = ptr__hamming_distance_bytes(pBig, small_array, small_array_size, max_dist);
-        if (res == 1)
-		{
+        if (res == 1){
             ret = i;
-			break;
+            break;
         }
-	}
+    }
 	
-	Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS
 	
     return Py_BuildValue("i", ret);
 }
@@ -377,10 +376,10 @@ static PyObject * check_bytes_arrays_best_within_dist_wrapper(PyObject *self, Py
         return NULL;
     }
 
-	int64_t best_dist = max_dist + 1;
-	int64_t best_index = -1;
+    int64_t best_dist = max_dist + 1;
+    int64_t best_index = -1;
 
-	Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS
 
     uint64_t dist;
     uint64_t number_of_elements = big_array_size / small_array_size;
@@ -388,18 +387,18 @@ static PyObject * check_bytes_arrays_best_within_dist_wrapper(PyObject *self, Py
     for (uint64_t i = 0; i < number_of_elements; i++, pBig += small_array_size) {
         dist = ptr__hamming_distance_bytes(pBig, small_array, small_array_size, -1);
         if (dist < best_dist) {
-			best_dist = dist;
-			best_index = i;
+            best_dist = dist;
+            best_index = i;
         }
-	}
+    }
 	
-	// Anything found? If not, set dist to -1
-	if (best_index == -1)
-	{
-		best_dist = -1;
-	}
+    // Anything found? If not, set dist to -1
+    if (best_index == -1)
+    {
+        best_dist = -1;
+    }
 	
-	Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS
 	
     return Py_BuildValue("ii", best_dist, best_index);
 }
@@ -444,45 +443,45 @@ static PyObject * check_bytes_arrays_all_within_dist_wrapper(PyObject *self, PyO
     }
 
     uint64_t number_of_elements = big_array_size / small_array_size;
-	uint64_t *out = new uint64_t[number_of_elements * 2];
-	uint64_t *o = out;
+    uint64_t *out = new uint64_t[number_of_elements * 2];
+    uint64_t *o = out;
 
-	Py_BEGIN_ALLOW_THREADS
+    Py_BEGIN_ALLOW_THREADS
 
     uint64_t dist;
     uint8_t* pBig = big_array;
     for (uint64_t i = 0; i < number_of_elements; i++, pBig += small_array_size) {
         dist = ptr__hamming_distance_bytes(pBig, small_array, small_array_size, -1);
         if (dist <= max_dist) {
-			*o++ = dist;
-			*o++ = i;
+            *o++ = dist;
+            *o++ = i;
         }
-	}
+    }
 	
-	Py_END_ALLOW_THREADS
+    Py_END_ALLOW_THREADS
 	
-	/* Assemble result... */
-	PyObject *my_list = PyList_New(0);
-	if ( my_list == NULL )  
-	{
-		PyErr_NoMemory();
-	}
+    /* Assemble result... */
+    PyObject *my_list = PyList_New(0);
+    if ( my_list == NULL )  
+    {
+        PyErr_NoMemory();
+    }
 	
-	for (uint64_t *op = out; op < o; op += 2)
-	{
-		PyObject *tup = Py_BuildValue("ii", op[0], op[1]);
-		if (tup == NULL)
-		{
-			PyErr_NoMemory();
-		}
+    for (uint64_t *op = out; op < o; op += 2)
+    {
+        PyObject *tup = Py_BuildValue("ii", op[0], op[1]);
+        if (tup == NULL)
+        {
+            PyErr_NoMemory();
+        }
 		
-		if(PyList_Append(my_list, tup) == -1) 
-		{
-			PyErr_NoMemory();
-		}
-	}
+        if(PyList_Append(my_list, tup) == -1) 
+        {
+            PyErr_NoMemory();
+        }
+    }
 	
-	delete [] out;
+    delete [] out;
 	
     return my_list;
 }

--- a/hexhamming/python_hexhamming.cc
+++ b/hexhamming/python_hexhamming.cc
@@ -172,7 +172,7 @@ static PyObject * hamming_distance_byte_wrapper(PyObject *self, PyObject *args) 
  * @param args      Python arguments for `check_hexstrings_within_dist` interface
  *                  - `string1` -- hex string
  *                  - `string2` -- hex string
- * @returns
+ * @returns			True if the hamming distance is less or equal to max_dist, False otherwise.
  */
 static PyObject * check_hexstrings_within_dist_wrapper(PyObject *self, PyObject *args) {
     char *input_s1;
@@ -234,16 +234,61 @@ static PyObject * check_hexstrings_within_dist_wrapper(PyObject *self, PyObject 
 }
 
 /**
- * Python interface for `check_bytes_arrays_within_dist`
+ * Python interface for `check_bytes_within_dist`
  *
  * @param self      Python `self` object
- * @param args      Python arguments for `check_bytes_arrays_within_dist` interface
+ * @param args      Python arguments for `check_bytes_arrays_first_within_dist` interface
+ *                  - `array_of_elems` - bytes
+ *                  - `elem_to_compare` - bytes
+ *                  - `max_dist` - int64
+ * @returns         True if the hamming distance is less or equal to max_dist, False otherwise.
+ */
+static PyObject * check_bytes_within_dist_wrapper(PyObject *self, PyObject *args) {
+    uint8_t *array_1, *array_2;
+    uint64_t array_1_size = 0;
+    uint64_t array_2_size = 0;
+    int64_t max_dist;
+
+    if (!PyArg_ParseTuple(args, "s#s#L", &array_1, &array_1_size, &array_2, &array_2_size, &max_dist)) {
+        PyErr_SetString(
+            PyExc_ValueError,
+            "error occurred while parsing arguments"
+        );
+        return NULL;
+    }
+
+    if (array_2_size == 0 || array_1_size == 0) {
+        PyErr_SetString(PyExc_ValueError, "array size must be >0");
+        return NULL;
+    }
+
+    if (max_dist < 0) {
+        PyErr_SetString(PyExc_ValueError, "`max_dist` must be >=0");
+        return NULL;
+    }
+
+    if (array_1_size != array_2_size) {
+        PyErr_SetString(PyExc_ValueError, "array sizes need to be the same");
+        return NULL;
+    }
+
+	int64_t result;
+	result = ptr__hamming_distance_bytes(array_1, array_2, array_2_size, max_dist);
+		
+    return Py_BuildValue("O", result == 1 ? Py_True : Py_False);
+}
+
+/**
+ * Python interface for `check_bytes_arrays_first_within_dist`
+ *
+ * @param self      Python `self` object
+ * @param args      Python arguments for `check_bytes_arrays_first_within_dist` interface
  *                  - `array_of_elems` - bytes
  *                  - `elem_to_compare` - bytes
  *                  - `max_dist` - int64
  * @returns         index of element in array_of_elems or -1.
  */
-static PyObject * check_bytes_arrays_within_dist_wrapper(PyObject *self, PyObject *args) {
+static PyObject * check_bytes_arrays_first_within_dist_wrapper(PyObject *self, PyObject *args) {
     uint8_t *big_array, *small_array;
     uint64_t big_array_size = 0;
     uint64_t small_array_size = 0;
@@ -272,15 +317,174 @@ static PyObject * check_bytes_arrays_within_dist_wrapper(PyObject *self, PyObjec
         return NULL;
     }
 
-    int res;
+    int64_t ret = -1;
+	
+	Py_BEGIN_ALLOW_THREADS
+	
+    uint64_t number_of_elements = big_array_size / small_array_size;
+    uint8_t* pBig = big_array;
+	uint64_t res;
+    for (uint64_t i = 0; i < number_of_elements; i++, pBig += small_array_size) {
+        res = ptr__hamming_distance_bytes(pBig, small_array, small_array_size, max_dist);
+        if (res == 1)
+		{
+            ret = i;
+			break;
+        }
+	}
+	
+	Py_END_ALLOW_THREADS
+	
+    return Py_BuildValue("i", ret);
+}
+
+/**
+ * Python interface for `check_bytes_arrays_best_within_dist`
+ *
+ * @param self      Python `self` object
+ * @param args      Python arguments for `check_bytes_arrays_first_within_dist` interface
+ *                  - `array_of_elems` - bytes
+ *                  - `elem_to_compare` - bytes
+ *                  - `max_dist` - int64
+ * @returns         tuple of best distance found and index of element in array_of_elems, or (-1, -1).
+ */
+static PyObject * check_bytes_arrays_best_within_dist_wrapper(PyObject *self, PyObject *args) {
+    uint8_t *big_array, *small_array;
+    uint64_t big_array_size = 0;
+    uint64_t small_array_size = 0;
+    int64_t max_dist;
+
+    if (!PyArg_ParseTuple(args, "s#s#L", &big_array, &big_array_size, &small_array, &small_array_size, &max_dist)) {
+        PyErr_SetString(
+            PyExc_ValueError,
+            "error occurred while parsing arguments"
+        );
+        return NULL;
+    }
+
+    if (small_array_size == 0) {
+        PyErr_SetString(PyExc_ValueError, "`elem_to_compare` size must be >0");
+        return NULL;
+    }
+
+    if (max_dist < 0) {
+        PyErr_SetString(PyExc_ValueError, "`max_dist` must be >=0");
+        return NULL;
+    }
+
+    if (big_array_size % small_array_size != 0) {
+        PyErr_SetString(PyExc_ValueError, "`array_of_elems` size must be multiplier of `elem_to_compare`");
+        return NULL;
+    }
+
+	int64_t best_dist = max_dist + 1;
+	int64_t best_index = -1;
+
+	Py_BEGIN_ALLOW_THREADS
+
+    uint64_t dist;
     uint64_t number_of_elements = big_array_size / small_array_size;
     uint8_t* pBig = big_array;
     for (uint64_t i = 0; i < number_of_elements; i++, pBig += small_array_size) {
-        res = (int)ptr__hamming_distance_bytes(pBig, small_array, small_array_size, max_dist);
-        if (res == 1)
-            return Py_BuildValue("i", i);
+        dist = ptr__hamming_distance_bytes(pBig, small_array, small_array_size, -1);
+        if (dist < best_dist) {
+			best_dist = dist;
+			best_index = i;
         }
-    return Py_BuildValue("i", -1);
+	}
+	
+	// Anything found? If not, set dist to -1
+	if (best_index == -1)
+	{
+		best_dist = -1;
+	}
+	
+	Py_END_ALLOW_THREADS
+	
+    return Py_BuildValue("ii", best_dist, best_index);
+}
+
+/**
+ * Python interface for `check_bytes_arrays_all_within_dist`
+ *
+ * @param self      Python `self` object
+ * @param args      Python arguments for `check_bytes_arrays_all_within_dist` interface
+ *                  - `array_of_elems` - bytes
+ *                  - `elem_to_compare` - bytes
+ *                  - `max_dist` - int64
+ * @returns         list of tuples of (distance, index) for all indices that have a distance < max_dist.
+ */
+static PyObject * check_bytes_arrays_all_within_dist_wrapper(PyObject *self, PyObject *args) {
+    uint8_t *big_array, *small_array;
+    uint64_t big_array_size = 0;
+    uint64_t small_array_size = 0;
+    int64_t max_dist;
+
+    if (!PyArg_ParseTuple(args, "s#s#L", &big_array, &big_array_size, &small_array, &small_array_size, &max_dist)) {
+        PyErr_SetString(
+            PyExc_ValueError,
+            "error occurred while parsing arguments"
+        );
+        return NULL;
+    }
+
+    if (small_array_size == 0) {
+        PyErr_SetString(PyExc_ValueError, "`elem_to_compare` size must be >0");
+        return NULL;
+    }
+
+    if (max_dist < 0) {
+        PyErr_SetString(PyExc_ValueError, "`max_dist` must be >=0");
+        return NULL;
+    }
+
+    if (big_array_size % small_array_size != 0) {
+        PyErr_SetString(PyExc_ValueError, "`array_of_elems` size must be multiplier of `elem_to_compare`");
+        return NULL;
+    }
+
+    uint64_t number_of_elements = big_array_size / small_array_size;
+	uint64_t *out = new uint64_t[number_of_elements * 2];
+	uint64_t *o = out;
+
+	Py_BEGIN_ALLOW_THREADS
+
+    uint64_t dist;
+    uint8_t* pBig = big_array;
+    for (uint64_t i = 0; i < number_of_elements; i++, pBig += small_array_size) {
+        dist = ptr__hamming_distance_bytes(pBig, small_array, small_array_size, -1);
+        if (dist <= max_dist) {
+			*o++ = dist;
+			*o++ = i;
+        }
+	}
+	
+	Py_END_ALLOW_THREADS
+	
+	/* Assemble result... */
+	PyObject *my_list = PyList_New(0);
+	if ( my_list == NULL )  
+	{
+		PyErr_NoMemory();
+	}
+	
+	for (uint64_t *op = out; op < o; op += 2)
+	{
+		PyObject *tup = Py_BuildValue("ii", op[0], op[1]);
+		if (tup == NULL)
+		{
+			PyErr_NoMemory();
+		}
+		
+		if(PyList_Append(my_list, tup) == -1) 
+		{
+			PyErr_NoMemory();
+		}
+	}
+	
+	delete [] out;
+	
+    return my_list;
 }
 
 /**
@@ -364,8 +568,7 @@ static char hamming_string_docstring[] =
 
 static char hamming_byte_docstring[] =
     "Calculate the hamming distance of two byte strings\n\n"
-    "with the only difference being it was written in C and optimized\n"
-    "using a lookup table of pre-calculated hexadecimal hamming distances.\n"
+    "with the only difference being it was written in C and optimized.\n"
     ":param a: hexadecimal string\n"
     ":type a: byte\n"
     ":param b: hexadecimal string\n"
@@ -388,11 +591,24 @@ static char check_hexstrings_within_dist_docstring[] =
     ":param max_dist: maximum allowable Hamming Distance\n"
     ":type max_dist: int\n"
     ":returns: whether or not the two hex strings are within `max_dist`\n"
-    ":rtype: int\n"
+    ":rtype: bool\n"
     ":raises ValueError: if either string doesn't exist, "
     "if the strings are different lengths, or if the strings aren't valid hex";
 
-static char check_bytes_arrays_within_dist_docstring[] =
+static char check_bytes_within_dist_docstring[] =
+    "Check if the byte strings are within a specified Hamming Distance\n\n"
+    ":param a: bytes array\n"
+    ":type a: bytes\n"
+    ":param b: bytes array\n"
+    ":type b: bytes\n"
+    ":param max_dist: maximum allowable Hamming Distance\n"
+    ":type max_dist: int\n"
+    ":returns: whether or not the two hex strings are within `max_dist`\n"
+    ":rtype: bool\n"
+    ":raises ValueError: if either string doesn't exist, "
+    "if the strings are different lengths.";
+
+static char check_bytes_arrays_first_within_dist_docstring[] =
     "Check if any element of byte array are within a specified Hamming Distance\n"
     "and return it's index or -1 otherwise.\n\n"
     "Size of `elem_to_compare ` must be multiplier of `array_of_elems` size. \n\n"
@@ -404,6 +620,34 @@ static char check_bytes_arrays_within_dist_docstring[] =
     ":type max_dist: int\n"
     ":returns: index of first element in array_of_elems for which hamming distance <= `max_dist` or -1. \n"
     ":rtype: int\n"
+    ":raises ValueError: if input parameters are invalid.";
+
+static char check_bytes_arrays_best_within_dist_docstring[] =
+    "Find element in bytes array that has the smallest Hamming distance to elem\n"
+    "and return the distance and it's index.\n\n"
+    "Size of `elem_to_compare ` must be multiplier of `array_of_elems` size. \n\n"
+    ":param array_of_elems: array of bytes to search within\n"
+    ":type array_of_elems: bytes\n"
+    ":param elem_to_compare: will compare to each element in array_of_elems\n"
+    ":type elem_to_compare: bytes\n"
+    ":param max_dist: maximum allowable Hamming Distance\n"
+    ":type max_dist: int\n"
+    ":returns: tuple of best distance and index of first element in array_of_elems with that hamming distance, or -1,-1 if not found.\n"
+    ":rtype: (int, int)\n"
+    ":raises ValueError: if input parameters are invalid.";
+
+static char check_bytes_arrays_all_within_dist_docstring[] =
+    "Find all elements in bytes array that have a Hamming distance to elem less than max_dist\n"
+    "and return a list of tuples of distance and index.\n\n"
+    "Size of `elem_to_compare ` must be multiplier of `array_of_elems` size. \n\n"
+    ":param array_of_elems: array of bytes to search within\n"
+    ":type array_of_elems: bytes\n"
+    ":param elem_to_compare: will compare to each element in array_of_elems\n"
+    ":type elem_to_compare: bytes\n"
+    ":param max_dist: maximum allowable Hamming Distance\n"
+    ":type max_dist: int\n"
+    ":returns: list of tuples of distance and index.\n"
+    ":rtype: [(int, int)]\n"
     ":raises ValueError: if input parameters are invalid.";
 
 static char set_algo_docstring[] =
@@ -422,8 +666,13 @@ static PyMethodDef CompareMethods[] = {
     {"hamming_distance_string", hamming_distance_string_wrapper, METH_VARARGS, hamming_string_docstring},
     {"hamming_distance_bytes", hamming_distance_byte_wrapper, METH_VARARGS, hamming_byte_docstring},
     {"check_hexstrings_within_dist", check_hexstrings_within_dist_wrapper, METH_VARARGS, check_hexstrings_within_dist_docstring},
-    {"check_bytes_arrays_within_dist", check_bytes_arrays_within_dist_wrapper, METH_VARARGS, check_bytes_arrays_within_dist_docstring},
+    {"check_bytes_within_dist", check_bytes_within_dist_wrapper, METH_VARARGS, check_bytes_within_dist_docstring},
+    {"check_bytes_arrays_first_within_dist", check_bytes_arrays_first_within_dist_wrapper, METH_VARARGS, check_bytes_arrays_first_within_dist_docstring},
+    {"check_bytes_arrays_best_within_dist", check_bytes_arrays_best_within_dist_wrapper, METH_VARARGS, check_bytes_arrays_best_within_dist_docstring},
+    {"check_bytes_arrays_all_within_dist", check_bytes_arrays_all_within_dist_wrapper, METH_VARARGS, check_bytes_arrays_all_within_dist_docstring},
     {"set_algo", set_algo_wrapper, METH_VARARGS, set_algo_docstring},
+	/* Alias for backwards compatibility */
+    {"check_bytes_arrays_within_dist", check_bytes_arrays_first_within_dist_wrapper, METH_VARARGS, check_bytes_arrays_first_within_dist_docstring},
     {NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION
Added cleaner APIs for array handling (find first, best, all matches)
Added GIL release for array ops
Added docs for array ops to Readme
Added tests for array ops
Added explicit `hamming_distance_byte` to have the same interface as `hamming_distance_string`. Functionally the find first array op does the same thing, but this being Python I'm weary of having two apparently interchangeable functions that have different return types, that just smells like trouble. ;)

It all seems to work fine, as far as I can tell. The only thing I don't understand is the benchmarking: the `best` and `all` array ops are about 2 orders of magnitude faster than the `first` one. Either the compiler does very high-level optimization magic, or something is wrong that I can't see...

Thanks!