### PR TITLE
Free GIL when running check_bytes_arrays_within_dist

### DIFF
--- a/hexhamming/python_hexhamming.cc
+++ b/hexhamming/python_hexhamming.cc
@@ -272,15 +272,24 @@ static PyObject * check_bytes_arrays_within_dist_wrapper(PyObject *self, PyObjec
         return NULL;
     }
 
+    int return_value = -1;
+
+    Py_BEGIN_ALLOW_THREADS
+
     int res;
     uint64_t number_of_elements = big_array_size / small_array_size;
     uint8_t* pBig = big_array;
     for (uint64_t i = 0; i < number_of_elements; i++, pBig += small_array_size) {
         res = (int)ptr__hamming_distance_bytes(pBig, small_array, small_array_size, max_dist);
-        if (res == 1)
-            return Py_BuildValue("i", i);
+        if (res == 1) {
+            return_value = i;
+            break;
         }
-    return Py_BuildValue("i", -1);
+    }
+
+    Py_END_ALLOW_THREADS
+
+    return Py_BuildValue("i", return_value);
 }
 
 /**

--- a/test/test_hexhamming.py
+++ b/test/test_hexhamming.py
@@ -309,3 +309,29 @@ def test_check_hexstrings_within_dist_bench(benchmark):
 )
 def test_check_bytes_arrays_within_dist_bench(benchmark, bytes1, bytes2, max_dist):
     benchmark(check_bytes_arrays_within_dist, bytes1, bytes2, max_dist)
+
+
+def test_check_bytes_arrays_within_dist_gil():
+    import threading
+    import time
+
+    def run_check():
+        big_array = b"\x00" * 16 * 1000000
+        small_array = b"\x00" * 16
+        max_dist = 0
+        result = check_bytes_arrays_within_dist(big_array, small_array, max_dist)
+        assert result == 0
+
+    def run_other_task():
+        for _ in range(5):
+            print("Running other task")
+            time.sleep(0.1)
+
+    check_thread = threading.Thread(target=run_check)
+    other_task_thread = threading.Thread(target=run_other_task)
+
+    check_thread.start()
+    other_task_thread.start()
+
+    check_thread.join()
+    other_task_thread.join()


### PR DESCRIPTION
Fixes #23

Add GIL release in `check_bytes_arrays_within_dist` function.

- Add `Py_BEGIN_ALLOW_THREADS` macro before the loop in `check_bytes_arrays_within_dist_wrapper` function in `hexhamming/python_hexhamming.cc`.
- Add `Py_END_ALLOW_THREADS` macro after the loop in `check_bytes_arrays_within_dist_wrapper` function in `hexhamming/python_hexhamming.cc`.
- Remove the in-loop return statement in `check_bytes_arrays_within_dist_wrapper` function in `hexhamming/python_hexhamming.cc`.
- Add unit test `test_check_bytes_arrays_within_dist_gil` in `test/test_hexhamming.py` to verify the functionality of `check_bytes_arrays_within_dist` function with GIL released.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mrecachinas/hexhamming/issues/23?shareId=XXXX-XXXX-XXXX-XXXX).