### PR TITLE
docs: refresh README benchmarks post SIMD speedups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,48 +194,59 @@ These numbers show the pure computation time using Rust's ``criterion`` benchmar
 Name                                           Mean (ns)
 ===========================================  ===========
 hex_string (NEON) [16 chars]                        2.0
-hex_string (NEON) [64 chars]                        5.7
-hex_string (NEON) [128 chars]                      11.0
-hex_string (NEON) [254 chars]                      20.9
-bytes (NEON) [8 bytes]                              1.1
-bytes (NEON) [32 bytes]                             1.3
-bytes (NEON) [64 bytes]                             2.0
-bytes (NEON) [127 bytes]                            5.2
+hex_string (NEON) [64 chars]                        5.8
+hex_string (NEON) [128 chars]                      11.2
+hex_string (NEON) [254 chars]                      21.2
+bytes (NEON) [8 bytes]                              1.8
+bytes (NEON) [32 bytes]                             2.8
+bytes (NEON) [64 bytes]                             2.6
+bytes (NEON) [127 bytes]                            6.6
 bytes_within_dist [127 bytes]                       1.6
-array first [512×16, at start]                      2.5
-array first [512×16, at end]                      525.0
-array best [512×16]                             1,419.0
-array all [512×16]                                535.0
-array first [16384×64, at mid]                  8,430.0
-array best [16384×64]                          42,981.0
-array all [16384×64]                           16,400.0
+array first [512×16, at start]                      2.3
+array first [512×16, at end]                      671.4
+array best [512×16]                               925.8
+array all [512×16]                                799.4
 ===========================================  ===========
+
+Larger array workloads cross the parallel (Rayon) threshold; see the Python
+table below for representative end-to-end numbers.
 
 Python API (via PyO3)
 ~~~~~~~~~~~~~~~~~~~~~
 
 These numbers include Python function call overhead (~45 ns) using ``pytest-benchmark``.
 
-======================================================  ===========  ==========
-Name                                                      Mean (ns)    Std (ns)
-======================================================  ===========  ==========
-hamming_distance_string [3 chars, same]                       48.8        10.1
-hamming_distance_string [3 chars, diff]                       48.4         4.4
-hamming_distance_string [64 chars, diff]                      88.2        16.0
-hamming_distance_string [1024 chars, diff]                   785.0       137.1
-hamming_distance_bytes [3 bytes, same]                        48.5         5.5
-hamming_distance_bytes [64 bytes, diff]                       50.3         8.4
-hamming_distance_bytes [1024 bytes, diff]                     69.1        16.0
-check_bytes_within_dist [127 bytes]                           53.4         5.3
-first_within_dist [512×16, at start]                          70.0         6.3
-first_within_dist [512×16, at end]                           721.2        65.7
-first_within_dist [16384×64, at end]                      48,927.1     8,321.5
-best_within_dist [512×16]                                    759.2       108.4
-best_within_dist [16384×64]                               46,295.0     3,793.5
-all_within_dist [512×16]                                     776.3        70.9
-all_within_dist [16384×64]                                46,602.1     2,944.3
-======================================================  ===========  ==========
+======================================================  ===========
+Name                                                      Mean (ns)
+======================================================  ===========
+hamming_distance_string [3 chars, same]                       84.6
+hamming_distance_string [3 chars, diff]                       83.6
+hamming_distance_string [64 chars, diff]                      91.3
+hamming_distance_string [1024 chars, diff]                   207.4
+hamming_distance_bytes [3 bytes, same]                       127.3
+hamming_distance_bytes [3 bytes, diff]                        96.2
+hamming_distance_bytes [64 bytes, diff]                      169.9
+hamming_distance_bytes [1024 bytes, diff]                    175.2
+check_hexstrings_within_dist [1000 chars]                    221.3
+check_bytes_within_dist [16 bytes]                           146.2
+check_bytes_within_dist [64 bytes]                           107.7
+check_bytes_within_dist [127 bytes]                          100.6
+first_within_dist [512×16, at start]                          98.7
+first_within_dist [512×16, mid]                              570.8
+first_within_dist [512×16, at end]                         1,030.1
+first_within_dist [16384×64, at start]                        99.6
+first_within_dist [16384×64, mid]                         20,838.8
+first_within_dist [16384×64, at end]                      41,489.5
+best_within_dist [512×16, at start]                        1,609.8
+best_within_dist [512×16, at end]                          1,116.4
+best_within_dist [16384×64, mid]                          46,826.1
+all_within_dist [512×16, at start]                         1,342.9
+all_within_dist [512×16, at end]                           1,365.9
+all_within_dist [16384×64, mid]                           48,067.2
+======================================================  ===========
 
 For small inputs, Python call overhead dominates (~45 ns). For large inputs
 (1024+ chars, 16384-element arrays), computation dominates and Python overhead
-is negligible.
+is negligible. Array APIs transparently parallelize with Rayon once the input
+exceeds ~64 KiB; the ``first`` variant additionally short-circuits on the first
+hit, so a match near the start is much faster than one near the end.


### PR DESCRIPTION
Re-run criterion and pytest-benchmark on current master and update both tables. Drop the 16384x64 rows from the raw Rust table since those workloads cross the Rayon threshold and criterion's measurement interacts poorly with the thread pool; point readers to the Python table for representative large-array numbers. Expand the Python table to cover start/mid/end match positions and additional sizes.