### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -284,7 +284,7 @@ jobs:
           EOF
 
       - name: Find existing comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         if: github.event.pull_request.head.repo.full_name == github.repository
         id: find-comment
         with:
@@ -293,7 +293,7 @@ jobs:
           body-includes: '📊 Benchmark Comparison Results'
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -56,7 +56,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: sdist
           args: --out dist
@@ -82,12 +82,12 @@ jobs:
 
       - name: Set up QEMU
         if: matrix.target == 'aarch64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: arm64
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.target == 'aarch64' && 'aarch64-apple-darwin' || 'x86_64-apple-darwin' }}
           args: --release --out dist
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
 
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           args: --release --out dist
 


### PR DESCRIPTION
Pins GitHub Actions `uses:` references in `mrecachinas/hexhamming` to immutable commit SHAs.

## Summary

| Metric | Count |
| --- | ---: |
| Files changed | 2 |
| Files scanned | 2 |
| Refs found | 10 |
| Refs pinned | 7 |
| Skipped refs | 23 |
| Warnings | 0 |
| Errors | 0 |

## Why

Pinning actions to full commit SHAs prevents future tag or branch retargeting from changing workflow behavior without review.

## Reviewer notes

- Original refs are preserved in inline comments when possible.
- Pin comments use the Dependabot-compatible original-ref style.
- Branch refs are skipped by default unless `--allow-branch-pins` is used.
- No minimum action age was enforced for this run.

## Pinned refs

| Location | Before | After | Resolved as |
| --- | --- | --- | --- |
| `.github/workflows/benchmark.yml:287` | `peter-evans/find-comment@v3` | `peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e` | `tag` |
| `.github/workflows/benchmark.yml:296` | `peter-evans/create-or-update-comment@v4` | `peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043` | `tag` |
| `.github/workflows/pythonpackage.yml:59` | `PyO3/maturin-action@v1` | `PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b` | `tag` |
| `.github/workflows/pythonpackage.yml:85` | `docker/setup-qemu-action@v3` | `docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130` | `tag` |
| `.github/workflows/pythonpackage.yml:90` | `PyO3/maturin-action@v1` | `PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b` | `tag` |
| `.github/workflows/pythonpackage.yml:121` | `PyO3/maturin-action@v1` | `PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b` | `tag` |
| `.github/workflows/pythonpackage.yml:143` | `PyO3/maturin-action@v1` | `PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b` | `tag` |

## Skipped refs

| Location | Ref | Reason |
| --- | --- | --- |
| `.github/workflows/benchmark.yml:17` | `actions/checkout@v4` | owner 'actions' is skipped by policy |
| `.github/workflows/benchmark.yml:22` | `actions/setup-python@v5` | owner 'actions' is skipped by policy |
| `.github/workflows/benchmark.yml:37` | `actions/upload-artifact@v4` | owner 'actions' is skipped by policy |
| `.github/workflows/benchmark.yml:48` | `actions/checkout@v4` | owner 'actions' is skipped by policy |
| `.github/workflows/benchmark.yml:51` | `actions/setup-python@v5` | owner 'actions' is skipped by policy |
| `.github/workflows/benchmark.yml:66` | `actions/upload-artifact@v4` | owner 'actions' is skipped by policy |
| `.github/workflows/benchmark.yml:78` | `actions/download-artifact@v4` | owner 'actions' is skipped by policy |
| `.github/workflows/benchmark.yml:84` | `actions/download-artifact@v4` | owner 'actions' is skipped by policy |
| `.github/workflows/benchmark.yml:90` | `actions/setup-python@v5` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:22` | `actions/checkout@v4.2.2` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:25` | `actions/setup-python@v5` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:53` | `actions/checkout@v4.2.2` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:65` | `actions/upload-artifact@v4` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:81` | `actions/checkout@v4.2.2` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:101` | `actions/upload-artifact@v4` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:118` | `actions/checkout@v4.2.2` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:127` | `actions/upload-artifact@v4` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:140` | `actions/checkout@v4.2.2` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:148` | `actions/upload-artifact@v4` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:165` | `actions/download-artifact@v4` | owner 'actions' is skipped by policy |
| `.github/workflows/pythonpackage.yml:30` | `dtolnay/rust-toolchain@stable` | branch ref skipped; pass --allow-branch-pins to pin branch HEADs |
| `.github/workflows/pythonpackage.yml:56` | `dtolnay/rust-toolchain@stable` | branch ref skipped; pass --allow-branch-pins to pin branch HEADs |
| `.github/workflows/pythonpackage.yml:172` | `pypa/gh-action-pypi-publish@release/v1` | branch ref skipped; pass --allow-branch-pins to pin branch HEADs |

---

Generated by pinner 0.1.0.
