### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
@@ -34,7 +34,7 @@ jobs:
           pytest test/ -k bench --benchmark-only --benchmark-json=results.json --benchmark-disable-gc
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: benchmark-base
           path: results.json
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 
@@ -63,7 +63,7 @@ jobs:
           pytest test/ -k bench --benchmark-only --benchmark-json=results.json --benchmark-disable-gc
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: benchmark-pr
           path: results.json
@@ -75,19 +75,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download base benchmark results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: benchmark-base
           path: base
 
       - name: Download PR benchmark results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: benchmark-pr
           path: pr
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,10 +19,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -62,7 +62,7 @@ jobs:
           args: --out dist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels-sdist
           path: dist/*.tar.gz
@@ -78,7 +78,7 @@ jobs:
         target: [x86_64, aarch64]
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up QEMU
         if: matrix.target == 'aarch64'
@@ -98,7 +98,7 @@ jobs:
             source $HOME/.cargo/env
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels-linux-${{ matrix.target }}
           path: dist/*.whl
@@ -115,7 +115,7 @@ jobs:
         target: [x86_64, aarch64]
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -124,7 +124,7 @@ jobs:
           args: --release --out dist
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels-macos-${{ matrix.target }}
           path: dist/*.whl
@@ -137,7 +137,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
@@ -145,7 +145,7 @@ jobs:
           args: --release --out dist
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: wheels-windows
           path: dist/*.whl
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           pattern: wheels-*


### PR DESCRIPTION
Pins GitHub Actions `uses:` references in `mrecachinas/hexhamming` to immutable commit SHAs.

## Summary

| Metric | Count |
| --- | ---: |
| Files changed | 2 |
| Files scanned | 2 |
| Refs found | 23 |
| Refs pinned | 20 |
| Skipped refs | 10 |
| Warnings | 0 |
| Errors | 0 |

## Why

Pinning actions to full commit SHAs prevents future tag or branch retargeting from changing workflow behavior without review.

## Reviewer notes

- Original refs are preserved in inline comments when possible.
- Pin comments use the Dependabot-compatible original-ref style.
- Branch refs are skipped by default unless `--allow-branch-pins` is used.
- No minimum action age was enforced for this run.

## Pinned refs

| Location | Before | After | Resolved as |
| --- | --- | --- | --- |
| `.github/workflows/benchmark.yml:17` | `actions/checkout@v4` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `tag` |
| `.github/workflows/benchmark.yml:22` | `actions/setup-python@v5` | `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065` | `tag` |
| `.github/workflows/benchmark.yml:37` | `actions/upload-artifact@v4` | `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` | `tag` |
| `.github/workflows/benchmark.yml:48` | `actions/checkout@v4` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `tag` |
| `.github/workflows/benchmark.yml:51` | `actions/setup-python@v5` | `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065` | `tag` |
| `.github/workflows/benchmark.yml:66` | `actions/upload-artifact@v4` | `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` | `tag` |
| `.github/workflows/benchmark.yml:78` | `actions/download-artifact@v4` | `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093` | `tag` |
| `.github/workflows/benchmark.yml:84` | `actions/download-artifact@v4` | `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093` | `tag` |
| `.github/workflows/benchmark.yml:90` | `actions/setup-python@v5` | `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065` | `tag` |
| `.github/workflows/pythonpackage.yml:22` | `actions/checkout@v4.2.2` | `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` | `tag` |
| `.github/workflows/pythonpackage.yml:25` | `actions/setup-python@v5` | `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065` | `tag` |
| `.github/workflows/pythonpackage.yml:53` | `actions/checkout@v4.2.2` | `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` | `tag` |
| `.github/workflows/pythonpackage.yml:65` | `actions/upload-artifact@v4` | `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` | `tag` |
| `.github/workflows/pythonpackage.yml:81` | `actions/checkout@v4.2.2` | `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` | `tag` |
| `.github/workflows/pythonpackage.yml:101` | `actions/upload-artifact@v4` | `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` | `tag` |
| `.github/workflows/pythonpackage.yml:118` | `actions/checkout@v4.2.2` | `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` | `tag` |
| `.github/workflows/pythonpackage.yml:127` | `actions/upload-artifact@v4` | `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` | `tag` |
| `.github/workflows/pythonpackage.yml:140` | `actions/checkout@v4.2.2` | `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` | `tag` |
| `.github/workflows/pythonpackage.yml:148` | `actions/upload-artifact@v4` | `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` | `tag` |
| `.github/workflows/pythonpackage.yml:165` | `actions/download-artifact@v4` | `actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093` | `tag` |

## Skipped refs

| Location | Ref | Reason |
| --- | --- | --- |
| `.github/workflows/benchmark.yml:287` | `peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e` | already pinned to a full SHA |
| `.github/workflows/benchmark.yml:296` | `peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043` | already pinned to a full SHA |
| `.github/workflows/pythonpackage.yml:59` | `PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b` | already pinned to a full SHA |
| `.github/workflows/pythonpackage.yml:85` | `docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130` | already pinned to a full SHA |
| `.github/workflows/pythonpackage.yml:90` | `PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b` | already pinned to a full SHA |
| `.github/workflows/pythonpackage.yml:121` | `PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b` | already pinned to a full SHA |
| `.github/workflows/pythonpackage.yml:143` | `PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b` | already pinned to a full SHA |
| `.github/workflows/pythonpackage.yml:30` | `dtolnay/rust-toolchain@stable` | branch ref skipped; pass --allow-branch-pins to pin branch HEADs |
| `.github/workflows/pythonpackage.yml:56` | `dtolnay/rust-toolchain@stable` | branch ref skipped; pass --allow-branch-pins to pin branch HEADs |
| `.github/workflows/pythonpackage.yml:172` | `pypa/gh-action-pypi-publish@release/v1` | branch ref skipped; pass --allow-branch-pins to pin branch HEADs |

---

Generated by pinner 0.1.0.
