### PR TITLE
Remove remaining array and Python overhead

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,24 +195,24 @@ These numbers show the pure computation time using Rust's ``criterion`` benchmar
 ================================================  ===========
 Name                                              Mean (ns)
 ================================================  ===========
-hex_string (NEON) [16 chars]                           2.4
-hex_string (NEON) [64 chars]                           8.3
-hex_string (NEON) [128 chars]                         16.2
-hex_string (NEON) [254 chars]                         30.2
-bytes (native) [8 bytes]                               1.7
-bytes (native) [32 bytes]                              2.4
-bytes (native) [64 bytes]                              3.2
-bytes (native) [127 bytes]                             8.4
-bytes_within_dist [127 bytes]                          2.4
-array first [512×16, at start]                         6.6
-array first [512×16, at end]                       1,397.0
-array best [512×16, exact at start]                     8.3
-array best [512×16, exact at end]                   1,599.2
-array all [512×16]                                  1,610.1
-array best [16384×64, match at mid]                71,121.0
-array all [16384×64, match at mid]                 79,365.0
-array best [100000×128, parallel]                  50,996.0
-array all [100000×128, parallel]                  144,800.0
+hex_string (NEON) [16 chars]                           1.6
+hex_string (NEON) [64 chars]                           5.4
+hex_string (NEON) [128 chars]                         10.5
+hex_string (NEON) [254 chars]                         19.7
+bytes (native) [8 bytes]                               1.1
+bytes (native) [32 bytes]                              1.5
+bytes (native) [64 bytes]                              2.1
+bytes (native) [127 bytes]                             5.5
+bytes_within_dist [127 bytes]                          1.6
+array first [512×16, at start]                         1.9
+array first [512×16, at end]                         402.4
+array best [512×16, exact at start]                     3.3
+array best [512×16, exact at end]                     526.4
+array all [512×16]                                    449.0
+array best [16384×64, match at mid]                10,986.0
+array all [16384×64, match at mid]                 20,350.0
+array best [100000×128, parallel]                  46,547.0
+array all [100000×128, parallel]                   99,266.0
 ================================================  ===========
 
 On AArch64, LLVM's auto-vectorized native byte loop is faster than the
@@ -229,35 +229,53 @@ These numbers include Python wrapper and function-call overhead using
 ======================================================  ===========
 Name                                                      Mean (ns)
 ======================================================  ===========
-hamming_distance_string [3 chars, same]                       56.3
-hamming_distance_string [3 chars, diff]                      105.8
-hamming_distance_string [64 chars, diff]                      60.0
-hamming_distance_string [1024 chars, diff]                   177.1
-hamming_distance_bytes [3 bytes, same]                        51.7
-hamming_distance_bytes [3 bytes, diff]                        51.8
-hamming_distance_bytes [64 bytes, diff]                       51.9
-hamming_distance_bytes [1024 bytes, diff]                     68.9
-check_hexstrings_within_dist [1000 chars]                     56.4
-check_bytes_within_dist [16 bytes]                            52.5
-check_bytes_within_dist [64 bytes]                            51.8
-check_bytes_within_dist [127 bytes]                           52.8
-first_within_dist [512×16, at start]                          58.5
-first_within_dist [512×16, mid]                              771.4
-first_within_dist [512×16, at end]                         1,475.1
-first_within_dist [16384×64, at start]                       160.3
-first_within_dist [16384×64, mid]                         23,031.5
-first_within_dist [16384×64, at end]                      45,801.2
-best_within_dist [512×16, at start]                           75.3
-best_within_dist [512×16, at end]                          1,703.5
-best_within_dist [16384×64, mid]                          93,212.8
-all_within_dist [512×16, at start]                         1,735.5
-all_within_dist [512×16, at end]                           1,747.3
-all_within_dist [16384×64, mid]                           93,056.3
+hamming_distance_string [3 chars, same]                       37.1
+hamming_distance_string [3 chars, diff]                       70.7
+hamming_distance_string [64 chars, diff]                      39.8
+hamming_distance_string [1024 chars, diff]                   116.4
+hamming_distance_bytes [3 bytes, same]                        33.4
+hamming_distance_bytes [3 bytes, diff]                        39.9
+hamming_distance_bytes [64 bytes, diff]                       33.9
+hamming_distance_bytes [1024 bytes, diff]                     44.6
+hamming_distance_bytes [64-byte bytearray]                    50.6
+hamming_distance_bytes [64-byte memoryview]                   51.5
+check_hexstrings_within_dist [1000 chars]                     37.3
+check_bytes_within_dist [16 bytes]                            34.3
+check_bytes_within_dist [64 bytes]                            33.7
+check_bytes_within_dist [127 bytes]                           34.7
+first_within_dist [512×16, at start]                          35.6
+first_within_dist [512×16, mid]                              240.7
+first_within_dist [512×16, at end]                           440.5
+first_within_dist [16384×64, at start]                        74.2
+first_within_dist [16384×64, mid]                         14,319.4
+first_within_dist [16384×64, at end]                      28,619.9
+best_within_dist [512×16, at start]                           47.0
+best_within_dist [512×16, at end]                            584.3
+best_within_dist [16384×64, mid]                          32,031.4
+all_within_dist [512×16, at start]                           530.4
+all_within_dist [512×16, at end]                             537.5
+all_within_dist [16384×64, mid]                           30,725.4
 ======================================================  ===========
 
-For small inputs, Python call and wrapper overhead dominates (roughly 40–55 ns
-on this machine). For large inputs
+For random inputs, the direct APIs also avoid the temporary big integers used
+by an equivalent standard-library implementation:
+
+================  ===============  ==============  ========
+Input             hexhamming (ns)  stdlib (ns)     Speedup
+================  ===============  ==============  ========
+bytes [16]                   33.5           158.3     4.72×
+bytes [64]                   37.4           233.1     6.24×
+bytes [1024]                 53.2         2,029.0    38.17×
+hex [16 chars]               37.2           126.3     3.39×
+hex [64 chars]               39.7           200.2     5.05×
+hex [1024 chars]            116.5         1,708.1    14.66×
+================  ===============  ==============  ========
+
+For small exact ``str`` and ``bytes`` inputs, Python call and wrapper overhead
+dominates (roughly 30–40 ns on this machine). For large inputs
 (1024+ chars, 16384-element arrays), computation dominates and Python overhead
-is negligible. Array APIs transparently parallelize with Rayon once the input
-exceeds ~64 KiB; the ``first`` variant additionally short-circuits on the first
-hit, so a match near the start is much faster than one near the end.
+is negligible. Byte operations release the GIL at 16 KiB, while immutable
+strings use a zero-copy detached path from 4 KiB. Array wrappers release the GIL
+at 64 KiB and parallelize with Rayon at 5 MiB; the ``first`` variant additionally
+short-circuits on the first hit, so a match near the start is much faster than
+one near the end.

--- a/benches/hamming_bench.rs
+++ b/benches/hamming_bench.rs
@@ -11,6 +11,19 @@ use hexhamming::hex_hamming_distance_pack;
 const HEX_SIZES: [usize; 5] = [16, 32, 64, 128, 254];
 const BYTE_SIZES: [usize; 5] = [8, 16, 32, 64, 127];
 
+fn pseudo_random_bytes(len: usize, seed: u64) -> Vec<u8> {
+    let mut state = seed;
+    (0..len)
+        .map(|_| {
+            state = state.wrapping_add(0x9E3779B97F4A7C15);
+            let mut value = state;
+            value = (value ^ (value >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            value = (value ^ (value >> 27)).wrapping_mul(0x94D049BB133111EB);
+            ((value ^ (value >> 31)) >> 56) as u8
+        })
+        .collect()
+}
+
 /// Benchmark hex hamming distance across all available algorithms
 fn bench_hex_by_algo(c: &mut Criterion) {
     let algos: &[&str] = if cfg!(target_arch = "x86_64") {
@@ -192,6 +205,88 @@ fn bench_array_api(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_array_random_and_boundaries(c: &mut Criterion) {
+    let small_16 = pseudo_random_bytes(16, 1);
+    let big_512x16 = pseudo_random_bytes(512 * 16, 2);
+    let mut group = c.benchmark_group("array_api/512x16_random_no_match");
+    group.bench_function("first", |bencher| {
+        bencher.iter(|| {
+            bytes_array_first_within_dist(
+                black_box(&big_512x16),
+                black_box(&small_16),
+                black_box(0),
+            )
+        })
+    });
+    group.bench_function("best", |bencher| {
+        bencher.iter(|| {
+            bytes_array_best_within_dist(black_box(&big_512x16), black_box(&small_16), black_box(0))
+        })
+    });
+    group.bench_function("all", |bencher| {
+        bencher.iter(|| {
+            bytes_array_all_within_dist(black_box(&big_512x16), black_box(&small_16), black_box(0))
+        })
+    });
+    group.finish();
+
+    let small_64 = pseudo_random_bytes(64, 3);
+    let big_16384x64 = pseudo_random_bytes(16_384 * 64, 4);
+    let mut group = c.benchmark_group("array_api/16384x64_random_no_match");
+    group.sample_size(30);
+    group.bench_function("first", |bencher| {
+        bencher.iter(|| {
+            bytes_array_first_within_dist(
+                black_box(&big_16384x64),
+                black_box(&small_64),
+                black_box(0),
+            )
+        })
+    });
+    group.bench_function("best", |bencher| {
+        bencher.iter(|| {
+            bytes_array_best_within_dist(
+                black_box(&big_16384x64),
+                black_box(&small_64),
+                black_box(0),
+            )
+        })
+    });
+    group.bench_function("all", |bencher| {
+        bencher.iter(|| {
+            bytes_array_all_within_dist(
+                black_box(&big_16384x64),
+                black_box(&small_64),
+                black_box(0),
+            )
+        })
+    });
+    group.finish();
+
+    let mut group = c.benchmark_group("array_api/parallel_boundary_64");
+    group.sample_size(30);
+    for num_elements in [4095usize, 4096, 65_536, 81_920, 131_072] {
+        let big = pseudo_random_bytes(num_elements * 64, 10 + num_elements as u64);
+        group.bench_function(format!("{num_elements} elements/all"), |bencher| {
+            bencher.iter(|| {
+                bytes_array_all_within_dist(black_box(&big), black_box(&small_64), black_box(0))
+            })
+        });
+        if num_elements >= 65_536 {
+            group.bench_function(format!("{num_elements} elements/best"), |bencher| {
+                bencher.iter(|| {
+                    bytes_array_best_within_dist(
+                        black_box(&big),
+                        black_box(&small_64),
+                        black_box(0),
+                    )
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
 #[cfg(target_arch = "aarch64")]
 fn bench_hex_string_pack(c: &mut Criterion) {
     // AArch64-only group for the packed NEON hex-string path.
@@ -213,6 +308,7 @@ criterion_group!(
     bench_bytes_by_algo,
     bench_bytes_within_dist,
     bench_array_api,
+    bench_array_random_and_boundaries,
     bench_hex_string_pack
 );
 #[cfg(not(target_arch = "aarch64"))]
@@ -221,6 +317,7 @@ criterion_group!(
     bench_hex_by_algo,
     bench_bytes_by_algo,
     bench_bytes_within_dist,
-    bench_array_api
+    bench_array_api,
+    bench_array_random_and_boundaries
 );
 criterion_main!(benches);

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,7 +9,7 @@ use rayon::prelude::*;
 use std::sync::atomic::Ordering;
 
 /// Minimum total byte size of big_array before we use rayon parallel paths.
-const PAR_THRESHOLD_BYTES: usize = 256 * 1024;
+const PAR_THRESHOLD_BYTES: usize = 5 * 1024 * 1024;
 /// Keep byte-array scans to a small number of coarse jobs. More workers spend
 /// more time scheduling these very small per-record calculations than running
 /// them on current many-core CPUs.

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
 use crate::{
-    hamming_distance_bytes_dispatch, hamming_distance_string_dispatch, ALGO_CLASSIC, ALGO_NATIVE,
-    CURRENT_ALGO,
+    hamming_distance_bytes_dispatch, hamming_distance_string_dispatch, select_bytes_kernel,
+    BytesKernel, ALGO_CLASSIC, ALGO_NATIVE, CURRENT_ALGO,
 };
 #[cfg(target_arch = "x86_64")]
 use crate::{ALGO_AVX2, ALGO_AVX512, ALGO_SSE41};
@@ -108,16 +108,26 @@ pub fn bytes_array_first_within_dist(
     // Parallelizing this requires a full non-short-circuiting scan to compute
     // the minimum matching index, which is dramatically slower for early/mid
     // matches and cannot beat serial for a match at index 0. Always go serial.
-    Ok(serial_first_within_dist(big_array, small_array, max_dist))
+    Ok(serial_first_within_dist(
+        big_array,
+        small_array,
+        max_dist,
+        select_bytes_kernel(),
+    ))
 }
 
 #[inline]
-fn serial_first_within_dist(big_array: &[u8], small_array: &[u8], max_dist: i64) -> Option<usize> {
+fn serial_first_within_dist(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+    kernel: BytesKernel,
+) -> Option<usize> {
     let elem_size = small_array.len();
     let num_elements = big_array.len() / elem_size;
     for i in 0..num_elements {
         let chunk = &big_array[i * elem_size..(i + 1) * elem_size];
-        if hamming_distance_bytes_dispatch(chunk, small_array, max_dist) != u64::MAX {
+        if kernel(chunk, small_array, max_dist) != u64::MAX {
             return Some(i);
         }
     }
@@ -138,8 +148,14 @@ pub fn bytes_array_best_within_dist(
     if big_array.len() % small_array.len() != 0 {
         return Err("array_of_elems size must be multiplier of elem_to_compare");
     }
+    let kernel = select_bytes_kernel();
     if big_array.len() < PAR_THRESHOLD_BYTES {
-        return Ok(serial_best_within_dist(big_array, small_array, max_dist));
+        return Ok(serial_best_within_dist(
+            big_array,
+            small_array,
+            max_dist,
+            kernel,
+        ));
     }
     let elem_size = small_array.len();
     let num_elements = big_array.len() / elem_size;
@@ -150,7 +166,7 @@ pub fn bytes_array_best_within_dist(
         .with_max_len(1)
         .map(|&(start, end)| {
             let chunk = &big_array[start * elem_size..end * elem_size];
-            serial_best_within_dist(chunk, small_array, max_dist)
+            serial_best_within_dist(chunk, small_array, max_dist, kernel)
                 .map(|(distance, index)| (distance, index + start))
         })
         .reduce(|| None, merge_best))
@@ -170,6 +186,7 @@ fn serial_best_within_dist(
     big_array: &[u8],
     small_array: &[u8],
     max_dist: i64,
+    kernel: BytesKernel,
 ) -> Option<(u64, usize)> {
     let elem_size = small_array.len();
     let num_elements = big_array.len() / elem_size;
@@ -179,7 +196,7 @@ fn serial_best_within_dist(
         let threshold = best
             .map(|(d, _)| (d as i64).saturating_sub(1))
             .unwrap_or(max_dist);
-        let d = hamming_distance_bytes_dispatch(chunk, small_array, threshold);
+        let d = kernel(chunk, small_array, threshold);
         if d == u64::MAX {
             continue;
         }
@@ -207,8 +224,14 @@ pub fn bytes_array_all_within_dist(
     if big_array.len() % small_array.len() != 0 {
         return Err("array_of_elems size must be multiplier of elem_to_compare");
     }
+    let kernel = select_bytes_kernel();
     if big_array.len() < PAR_THRESHOLD_BYTES {
-        return Ok(serial_all_within_dist(big_array, small_array, max_dist));
+        return Ok(serial_all_within_dist(
+            big_array,
+            small_array,
+            max_dist,
+            kernel,
+        ));
     }
     let elem_size = small_array.len();
     let num_elements = big_array.len() / elem_size;
@@ -218,7 +241,7 @@ pub fn bytes_array_all_within_dist(
         .with_max_len(1)
         .map(|&(start, end)| {
             let chunk = &big_array[start * elem_size..end * elem_size];
-            serial_all_within_dist(chunk, small_array, max_dist)
+            serial_all_within_dist(chunk, small_array, max_dist, kernel)
                 .into_iter()
                 .map(|(distance, index)| (distance, index + start))
                 .collect()
@@ -240,13 +263,14 @@ fn serial_all_within_dist(
     big_array: &[u8],
     small_array: &[u8],
     max_dist: i64,
+    kernel: BytesKernel,
 ) -> Vec<(u64, usize)> {
     let elem_size = small_array.len();
     let num_elements = big_array.len() / elem_size;
     let mut results = Vec::new();
     for i in 0..num_elements {
         let chunk = &big_array[i * elem_size..(i + 1) * elem_size];
-        let d = hamming_distance_bytes_dispatch(chunk, small_array, max_dist);
+        let d = kernel(chunk, small_array, max_dist);
         if d != u64::MAX {
             results.push((d, i));
         }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,6 +1,6 @@
 use crate::{
-    hamming_distance_bytes_dispatch, hamming_distance_string_dispatch, select_bytes_kernel,
-    BytesKernel, ALGO_CLASSIC, ALGO_NATIVE, CURRENT_ALGO,
+    hamming_distance_bytes_dispatch, hamming_distance_string_dispatch,
+    select_bytes_kernel_for_width, BytesKernel, ALGO_CLASSIC, ALGO_NATIVE, CURRENT_ALGO,
 };
 #[cfg(target_arch = "x86_64")]
 use crate::{ALGO_AVX2, ALGO_AVX512, ALGO_SSE41};
@@ -112,7 +112,7 @@ pub fn bytes_array_first_within_dist(
         big_array,
         small_array,
         max_dist,
-        select_bytes_kernel(),
+        select_bytes_kernel_for_width(small_array.len()),
     ))
 }
 
@@ -148,7 +148,7 @@ pub fn bytes_array_best_within_dist(
     if big_array.len() % small_array.len() != 0 {
         return Err("array_of_elems size must be multiplier of elem_to_compare");
     }
-    let kernel = select_bytes_kernel();
+    let kernel = select_bytes_kernel_for_width(small_array.len());
     if big_array.len() < PAR_THRESHOLD_BYTES {
         return Ok(serial_best_within_dist(
             big_array,
@@ -224,7 +224,7 @@ pub fn bytes_array_all_within_dist(
     if big_array.len() % small_array.len() != 0 {
         return Err("array_of_elems size must be multiplier of elem_to_compare");
     }
-    let kernel = select_bytes_kernel();
+    let kernel = select_bytes_kernel_for_width(small_array.len());
     if big_array.len() < PAR_THRESHOLD_BYTES {
         return Ok(serial_all_within_dist(
             big_array,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,11 @@ pub(crate) static CURRENT_ALGO: AtomicU8 = AtomicU8::new(ALGO_NATIVE);
 
 pub(crate) type BytesKernel = fn(&[u8], &[u8], i64) -> u64;
 
+#[inline]
+fn hamming_distance_bytes_native_16(a: &[u8], b: &[u8], max_dist: i64) -> u64 {
+    native::hamming_distance_bytes_native_16(a, b, max_dist)
+}
+
 #[cfg(target_arch = "x86_64")]
 #[inline]
 fn hamming_distance_bytes_avx512(a: &[u8], b: &[u8], max_dist: i64) -> u64 {
@@ -116,9 +121,7 @@ fn hamming_distance_bytes_neon(a: &[u8], b: &[u8], max_dist: i64) -> u64 {
 /// Resolve the byte-distance backend once for callers that perform many
 /// comparisons with the same algorithm selection.
 #[inline]
-pub(crate) fn select_bytes_kernel() -> BytesKernel {
-    let algo = CURRENT_ALGO.load(Ordering::Relaxed);
-
+fn select_bytes_kernel_for_algo(algo: u8) -> BytesKernel {
     match algo {
         ALGO_CLASSIC => classic::hamming_distance_bytes_classic,
 
@@ -156,6 +159,15 @@ pub(crate) fn select_bytes_kernel() -> BytesKernel {
 
         _ => native::hamming_distance_bytes_native,
     }
+}
+
+#[inline]
+pub(crate) fn select_bytes_kernel_for_width(width: usize) -> BytesKernel {
+    let algo = CURRENT_ALGO.load(Ordering::Relaxed);
+    if algo == ALGO_NATIVE && width == 16 {
+        return hamming_distance_bytes_native_16;
+    }
+    select_bytes_kernel_for_algo(algo)
 }
 
 /// Dispatch to the byte distance implementation selected by `CURRENT_ALGO`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,77 @@ pub(crate) const SSE_THRESHOLD: usize = 64; // Use SSE for medium strings
 /// implementations produce identical results.
 pub(crate) static CURRENT_ALGO: AtomicU8 = AtomicU8::new(ALGO_NATIVE);
 
+pub(crate) type BytesKernel = fn(&[u8], &[u8], i64) -> u64;
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn hamming_distance_bytes_avx512(a: &[u8], b: &[u8], max_dist: i64) -> u64 {
+    unsafe { x86_simd::hamming_distance_bytes_avx512(a, b, max_dist) }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn hamming_distance_bytes_avx2(a: &[u8], b: &[u8], max_dist: i64) -> u64 {
+    unsafe { x86_simd::hamming_distance_bytes_avx2(a, b, max_dist) }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn hamming_distance_bytes_sse(a: &[u8], b: &[u8], max_dist: i64) -> u64 {
+    unsafe { x86_simd::hamming_distance_bytes_sse(a, b, max_dist) }
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline]
+fn hamming_distance_bytes_neon(a: &[u8], b: &[u8], max_dist: i64) -> u64 {
+    unsafe { neon_simd::hamming_distance_bytes_neon(a, b, max_dist) }
+}
+
+/// Resolve the byte-distance backend once for callers that perform many
+/// comparisons with the same algorithm selection.
+#[inline]
+pub(crate) fn select_bytes_kernel() -> BytesKernel {
+    let algo = CURRENT_ALGO.load(Ordering::Relaxed);
+
+    match algo {
+        ALGO_CLASSIC => classic::hamming_distance_bytes_classic,
+
+        #[cfg(target_arch = "x86_64")]
+        ALGO_AVX512 => {
+            if is_x86_feature_detected!("avx512bw") && is_x86_feature_detected!("avx512bitalg") {
+                hamming_distance_bytes_avx512
+            } else if is_x86_feature_detected!("avx2") {
+                hamming_distance_bytes_avx2
+            } else {
+                native::hamming_distance_bytes_native
+            }
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        ALGO_AVX2 => {
+            if is_x86_feature_detected!("avx2") {
+                hamming_distance_bytes_avx2
+            } else {
+                native::hamming_distance_bytes_native
+            }
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        ALGO_SSE41 => {
+            if is_x86_feature_detected!("sse4.1") && is_x86_feature_detected!("popcnt") {
+                hamming_distance_bytes_sse
+            } else {
+                native::hamming_distance_bytes_native
+            }
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        ALGO_NEON => hamming_distance_bytes_neon,
+
+        _ => native::hamming_distance_bytes_native,
+    }
+}
+
 /// Dispatch to the byte distance implementation selected by `CURRENT_ALGO`.
 ///
 /// Callers validate equal lengths before reaching this layer. `max_dist < 0`

--- a/src/native.rs
+++ b/src/native.rs
@@ -102,6 +102,26 @@ pub(crate) fn hamming_distance_bytes_native(a: &[u8], b: &[u8], max_dist: i64) -
     }
 }
 
+#[inline(always)]
+pub(crate) fn hamming_distance_bytes_native_16(a: &[u8], b: &[u8], max_dist: i64) -> u64 {
+    debug_assert_eq!(a.len(), 16);
+    debug_assert_eq!(b.len(), 16);
+
+    let difference = unsafe {
+        let a0 = u64::from_ne_bytes(*(a.as_ptr() as *const [u8; 8]));
+        let b0 = u64::from_ne_bytes(*(b.as_ptr() as *const [u8; 8]));
+        let a1 = u64::from_ne_bytes(*(a.as_ptr().add(8) as *const [u8; 8]));
+        let b1 = u64::from_ne_bytes(*(b.as_ptr().add(8) as *const [u8; 8]));
+        popcnt64_native(a0 ^ b0) + popcnt64_native(a1 ^ b1)
+    };
+    let max_dist_u64 = max_dist as u64;
+    if max_dist >= 0 && difference > max_dist_u64 {
+        u64::MAX
+    } else {
+        difference
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -153,6 +173,19 @@ mod tests {
                 hamming_distance_bytes_native(&a, &b, -1),
                 hamming_distance_bytes_classic(&a, &b, -1),
                 "mismatch at size {size}"
+            );
+        }
+    }
+
+    #[test]
+    fn bytes_native_16_agrees_with_generic() {
+        let a: Vec<u8> = (0..16).map(|i| i as u8).collect();
+        let b: Vec<u8> = (0..16).map(|i| (i as u8).wrapping_mul(17)).collect();
+        for max_dist in [-1, 0, 1, 63, 64] {
+            assert_eq!(
+                hamming_distance_bytes_native_16(&a, &b, max_dist),
+                hamming_distance_bytes_native(&a, &b, max_dist),
+                "mismatch at max_dist {max_dist}"
             );
         }
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -32,7 +32,8 @@ use pyo3::types::{PyBytes, PyBytesMethods};
 /// borrowed bytes while holding the GIL (sound: the borrow is valid for the
 /// whole synchronous call). Above it, releasing the GIL lets other Python
 /// threads make progress and the copy is amortized.
-const GIL_RELEASE_THRESHOLD: usize = 4096;
+const STRING_GIL_RELEASE_THRESHOLD: usize = 4096;
+const BYTES_GIL_RELEASE_THRESHOLD: usize = 16 * 1024;
 const ARRAY_GIL_RELEASE_THRESHOLD: usize = 64 * 1024;
 
 #[inline]
@@ -132,7 +133,7 @@ fn hamming_distance_string(py: Python<'_>, a: &str, b: &str) -> PyResult<u64> {
     let b_bytes = b.as_bytes();
     // Small inputs: compute on the borrowed bytes while holding the GIL — no
     // allocation, no GIL round-trip. The borrows are valid for the whole call.
-    if a_bytes.len() < GIL_RELEASE_THRESHOLD {
+    if a_bytes.len() < STRING_GIL_RELEASE_THRESHOLD {
         return hamming_distance_string_dispatch(a_bytes, b_bytes).map_err(PyValueError::new_err);
     }
     // Python strings are immutable and remain borrowed for the whole call, so
@@ -166,7 +167,7 @@ fn hamming_distance_bytes(
         if a_slice.is_empty() {
             return Ok(0);
         }
-        if a_slice.len() < GIL_RELEASE_THRESHOLD {
+        if a_slice.len() < BYTES_GIL_RELEASE_THRESHOLD {
             return Ok(hamming_distance_bytes_dispatch(a_slice, b_slice, -1));
         }
     }
@@ -186,7 +187,7 @@ fn hamming_distance_bytes(
     }
 
     // Small inputs: skip the GIL round-trip (already zero-copy via PyBuffer).
-    let result = if a_slice.len() < GIL_RELEASE_THRESHOLD {
+    let result = if a_slice.len() < BYTES_GIL_RELEASE_THRESHOLD {
         hamming_distance_bytes_dispatch(a_slice, b_slice, -1)
     } else {
         py.detach(move || hamming_distance_bytes_dispatch(a_slice, b_slice, -1))
@@ -310,7 +311,7 @@ fn check_bytes_within_dist(
         if a_slice.len() != b_slice.len() {
             return Err(PyValueError::new_err("array sizes need to be the same"));
         }
-        if a_slice.len() < GIL_RELEASE_THRESHOLD {
+        if a_slice.len() < BYTES_GIL_RELEASE_THRESHOLD {
             return Ok(hamming_distance_bytes_dispatch(a_slice, b_slice, max_dist) != u64::MAX);
         }
     }
@@ -332,7 +333,7 @@ fn check_bytes_within_dist(
         return Err(PyValueError::new_err("array sizes need to be the same"));
     }
 
-    let result = if a_slice.len() < GIL_RELEASE_THRESHOLD {
+    let result = if a_slice.len() < BYTES_GIL_RELEASE_THRESHOLD {
         hamming_distance_bytes_dispatch(a_slice, b_slice, max_dist)
     } else {
         py.detach(move || hamming_distance_bytes_dispatch(a_slice, b_slice, max_dist))

--- a/src/python.rs
+++ b/src/python.rs
@@ -135,11 +135,9 @@ fn hamming_distance_string(py: Python<'_>, a: &str, b: &str) -> PyResult<u64> {
     if a_bytes.len() < GIL_RELEASE_THRESHOLD {
         return hamming_distance_string_dispatch(a_bytes, b_bytes).map_err(PyValueError::new_err);
     }
-    // Large inputs: copy into owned buffers (so the closure is `Ungil`) and
-    // release the GIL so other Python threads can run during the computation.
-    let a_owned = a_bytes.to_vec();
-    let b_owned = b_bytes.to_vec();
-    py.detach(move || hamming_distance_string_dispatch(&a_owned, &b_owned))
+    // Python strings are immutable and remain borrowed for the whole call, so
+    // their byte slices can be processed while the interpreter is detached.
+    py.detach(|| hamming_distance_string_dispatch(a_bytes, b_bytes))
         .map_err(PyValueError::new_err)
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -7,15 +7,19 @@ use crate::{
 #[cfg(target_arch = "x86_64")]
 use crate::{ALGO_AVX2, ALGO_AVX512, ALGO_SSE41};
 
+use std::ffi::CStr;
+use std::marker::PhantomPinned;
+use std::pin::Pin;
 use std::sync::atomic::Ordering;
 
-use pyo3::buffer::PyBuffer;
+use pyo3::buffer::Element;
 use pyo3::exceptions::PyValueError;
+use pyo3::ffi;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyBytesMethods};
 
 // ---------------------------------------------------------------------------
-// §5 helper: zero-copy slice from a PyBuffer
+// §5 helper: zero-copy slice from the Python buffer protocol
 // ---------------------------------------------------------------------------
 
 /// Minimum input length (bytes/chars) before it is worth releasing the GIL.
@@ -36,20 +40,75 @@ fn exact_bytes<'a>(obj: &'a Bound<'_, PyAny>) -> Option<&'a [u8]> {
     obj.cast::<PyBytes>().ok().map(PyBytesMethods::as_bytes)
 }
 
-/// Extract a contiguous `PyBuffer<u8>` from any buffer-protocol object.
-fn extract_buffer(obj: &Bound<'_, PyAny>) -> PyResult<PyBuffer<u8>> {
-    let buf: PyBuffer<u8> = PyBuffer::get(obj)
-        .map_err(|_| PyValueError::new_err("error occurred while parsing arguments"))?;
-    if !buf.is_c_contiguous() {
-        return Err(PyValueError::new_err("input must be contiguous"));
-    }
-    Ok(buf)
+struct SimpleByteBuffer {
+    raw: ffi::Py_buffer,
+    acquired: bool,
+    _pin: PhantomPinned,
 }
 
-/// SAFETY: caller must ensure `buf` is C-contiguous and remains alive for `'a`.
-#[inline]
-unsafe fn buffer_as_slice<'a>(buf: &'a PyBuffer<u8>) -> &'a [u8] {
-    std::slice::from_raw_parts(buf.buf_ptr() as *const u8, buf.item_count())
+impl SimpleByteBuffer {
+    fn new() -> Self {
+        Self {
+            raw: ffi::Py_buffer::new(),
+            acquired: false,
+            _pin: PhantomPinned,
+        }
+    }
+
+    fn acquire(mut self: Pin<&mut Self>, obj: &Bound<'_, PyAny>) -> PyResult<()> {
+        let this = unsafe { self.as_mut().get_unchecked_mut() };
+        let result = unsafe {
+            ffi::PyObject_GetBuffer(
+                obj.as_ptr(),
+                &mut this.raw,
+                ffi::PyBUF_ND | ffi::PyBUF_FORMAT,
+            )
+        };
+        if result != 0 {
+            let _ = PyErr::fetch(obj.py());
+            let message = if unsafe { ffi::PyObject_CheckBuffer(obj.as_ptr()) } != 0 {
+                "input must be contiguous"
+            } else {
+                "error occurred while parsing arguments"
+            };
+            return Err(PyValueError::new_err(message));
+        }
+        this.acquired = true;
+
+        let compatible_format = if this.raw.format.is_null() {
+            false
+        } else {
+            let format = unsafe { CStr::from_ptr(this.raw.format) };
+            <u8 as Element>::is_compatible_format(format)
+        };
+        if this.raw.itemsize != 1 || !compatible_format {
+            return Err(PyValueError::new_err(
+                "error occurred while parsing arguments",
+            ));
+        }
+        if this.raw.len < 0 || (this.raw.buf.is_null() && this.raw.len != 0) {
+            return Err(PyValueError::new_err("invalid buffer view"));
+        }
+        Ok(())
+    }
+
+    /// SAFETY: the pinned guard keeps the exported buffer alive and stationary
+    /// for the returned slice's lifetime.
+    #[inline]
+    unsafe fn as_slice(self: Pin<&Self>) -> &[u8] {
+        let raw = &self.get_ref().raw;
+        std::slice::from_raw_parts(raw.buf as *const u8, raw.len as usize)
+    }
+}
+
+impl Drop for SimpleByteBuffer {
+    fn drop(&mut self) {
+        if self.acquired {
+            let _ = Python::try_attach(|_| unsafe {
+                ffi::PyBuffer_Release(&mut self.raw);
+            });
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -114,11 +173,12 @@ fn hamming_distance_bytes(
         }
     }
 
-    let buf_a = extract_buffer(a)?;
-    let buf_b = extract_buffer(b)?;
-    // SAFETY: buffers are C-contiguous; PyBuffer pins the Python object.
-    let a_slice = unsafe { buffer_as_slice(&buf_a) };
-    let b_slice = unsafe { buffer_as_slice(&buf_b) };
+    let mut buf_a = std::pin::pin!(SimpleByteBuffer::new());
+    let mut buf_b = std::pin::pin!(SimpleByteBuffer::new());
+    buf_a.as_mut().acquire(a)?;
+    buf_b.as_mut().acquire(b)?;
+    let a_slice = unsafe { buf_a.as_ref().as_slice() };
+    let b_slice = unsafe { buf_b.as_ref().as_slice() };
 
     if a_slice.len() != b_slice.len() {
         return Err(PyValueError::new_err("bytes are NOT the same length"));
@@ -133,8 +193,6 @@ fn hamming_distance_bytes(
     } else {
         py.detach(move || hamming_distance_bytes_dispatch(a_slice, b_slice, -1))
     };
-    drop(buf_a);
-    drop(buf_b);
     Ok(result)
 }
 
@@ -259,10 +317,12 @@ fn check_bytes_within_dist(
         }
     }
 
-    let buf_a = extract_buffer(a)?;
-    let buf_b = extract_buffer(b)?;
-    let a_slice = unsafe { buffer_as_slice(&buf_a) };
-    let b_slice = unsafe { buffer_as_slice(&buf_b) };
+    let mut buf_a = std::pin::pin!(SimpleByteBuffer::new());
+    let mut buf_b = std::pin::pin!(SimpleByteBuffer::new());
+    buf_a.as_mut().acquire(a)?;
+    buf_b.as_mut().acquire(b)?;
+    let a_slice = unsafe { buf_a.as_ref().as_slice() };
+    let b_slice = unsafe { buf_b.as_ref().as_slice() };
 
     if a_slice.is_empty() || b_slice.is_empty() {
         return Err(PyValueError::new_err("array size must be >0"));
@@ -279,8 +339,6 @@ fn check_bytes_within_dist(
     } else {
         py.detach(move || hamming_distance_bytes_dispatch(a_slice, b_slice, max_dist))
     };
-    drop(buf_a);
-    drop(buf_b);
     Ok(result != u64::MAX)
 }
 
@@ -339,10 +397,12 @@ fn check_bytes_arrays_first_within_dist(
         }
     }
 
-    let buf_big = extract_buffer(array_of_elems)?;
-    let buf_small = extract_buffer(elem_to_compare)?;
-    let big_slice = unsafe { buffer_as_slice(&buf_big) };
-    let small_slice = unsafe { buffer_as_slice(&buf_small) };
+    let mut buf_big = std::pin::pin!(SimpleByteBuffer::new());
+    let mut buf_small = std::pin::pin!(SimpleByteBuffer::new());
+    buf_big.as_mut().acquire(array_of_elems)?;
+    buf_small.as_mut().acquire(elem_to_compare)?;
+    let big_slice = unsafe { buf_big.as_ref().as_slice() };
+    let small_slice = unsafe { buf_small.as_ref().as_slice() };
 
     if small_slice.is_empty() {
         return Err(PyValueError::new_err("`elem_to_compare` size must be >0"));
@@ -370,8 +430,6 @@ fn check_bytes_arrays_first_within_dist(
     } else {
         py.detach(calculate)
     };
-    drop(buf_big);
-    drop(buf_small);
     Ok(result)
 }
 
@@ -415,10 +473,12 @@ fn check_bytes_arrays_best_within_dist(
         }
     }
 
-    let buf_big = extract_buffer(array_of_elems)?;
-    let buf_small = extract_buffer(elem_to_compare)?;
-    let big_slice = unsafe { buffer_as_slice(&buf_big) };
-    let small_slice = unsafe { buffer_as_slice(&buf_small) };
+    let mut buf_big = std::pin::pin!(SimpleByteBuffer::new());
+    let mut buf_small = std::pin::pin!(SimpleByteBuffer::new());
+    buf_big.as_mut().acquire(array_of_elems)?;
+    buf_small.as_mut().acquire(elem_to_compare)?;
+    let big_slice = unsafe { buf_big.as_ref().as_slice() };
+    let small_slice = unsafe { buf_small.as_ref().as_slice() };
 
     if small_slice.is_empty() {
         return Err(PyValueError::new_err("`elem_to_compare` size must be >0"));
@@ -444,8 +504,6 @@ fn check_bytes_arrays_best_within_dist(
     } else {
         py.detach(calculate)
     };
-    drop(buf_big);
-    drop(buf_small);
     Ok(result)
 }
 
@@ -488,10 +546,12 @@ fn check_bytes_arrays_all_within_dist(
         }
     }
 
-    let buf_big = extract_buffer(array_of_elems)?;
-    let buf_small = extract_buffer(elem_to_compare)?;
-    let big_slice = unsafe { buffer_as_slice(&buf_big) };
-    let small_slice = unsafe { buffer_as_slice(&buf_small) };
+    let mut buf_big = std::pin::pin!(SimpleByteBuffer::new());
+    let mut buf_small = std::pin::pin!(SimpleByteBuffer::new());
+    buf_big.as_mut().acquire(array_of_elems)?;
+    buf_small.as_mut().acquire(elem_to_compare)?;
+    let big_slice = unsafe { buf_big.as_ref().as_slice() };
+    let small_slice = unsafe { buf_small.as_ref().as_slice() };
 
     if small_slice.is_empty() {
         return Err(PyValueError::new_err("`elem_to_compare` size must be >0"));
@@ -517,8 +577,6 @@ fn check_bytes_arrays_all_within_dist(
     } else {
         py.detach(calculate)
     };
-    drop(buf_big);
-    drop(buf_small);
     Ok(results)
 }
 

--- a/test/test_hexhamming.py
+++ b/test/test_hexhamming.py
@@ -453,6 +453,18 @@ def test_hamming_distance_bytes_bench(benchmark, hex1, hex2):
     benchmark(hamming_distance_bytes, hex1, hex2)
 
 
+@pytest.mark.benchmark(group="hamming_distance_bytes_buffer")
+@pytest.mark.parametrize(
+    "factory",
+    (bytearray, memoryview),
+    ids=("bytearray", "memoryview"),
+)
+def test_hamming_distance_bytes_buffer_bench(benchmark, factory):
+    a = factory(b"\xff" * 64)
+    b = factory(b"\x00" * 64)
+    benchmark(hamming_distance_bytes, a, b)
+
+
 def test_check_hexstrings_within_dist_bench(benchmark):
     benchmark(check_hexstrings_within_dist, "F" * 1000, "0" * 1000, 20)
 
@@ -604,6 +616,12 @@ def test_hamming_distance_bytes_memoryview():
     assert hamming_distance_bytes(a, b) == 16
 
 
+def test_hamming_distance_bytes_noncontiguous_memoryview():
+    a = memoryview(b"\xff\x00\xff\x00")[::2]
+    with pytest.raises(ValueError, match="input must be contiguous"):
+        hamming_distance_bytes(a, a)
+
+
 def test_check_bytes_within_dist_bytearray():
     a = bytearray(b"\xff\x00")
     b = bytearray(b"\xfe\x00")
@@ -655,6 +673,13 @@ def test_hamming_distance_bytes_numpy():
     a = np.array([0xFF, 0x00], dtype=np.uint8)
     b = np.array([0x00, 0xFF], dtype=np.uint8)
     assert hamming_distance_bytes(a, b) == 16
+
+
+@pytest.mark.skipif(not HAS_NUMPY, reason="numpy not installed")
+def test_hamming_distance_bytes_numpy_wide_dtype_rejected():
+    a = np.array([0xFF, 0x00], dtype=np.uint32)
+    with pytest.raises(ValueError, match="error occurred while parsing arguments"):
+        hamming_distance_bytes(a, a)
 
 
 @pytest.mark.skipif(not HAS_NUMPY, reason="numpy not installed")

--- a/test/test_performance_matrix.py
+++ b/test/test_performance_matrix.py
@@ -1,0 +1,58 @@
+import random
+
+import pytest
+
+from hexhamming import hamming_distance_bytes, hamming_distance_string
+
+
+def random_bytes(size):
+    rng = random.Random(0xC0FFEE + size)
+    return bytes(rng.randrange(256) for _ in range(size))
+
+
+def stdlib_bytes_distance(a, b):
+    return (int.from_bytes(a, "big") ^ int.from_bytes(b, "big")).bit_count()
+
+
+def stdlib_hex_distance(a, b):
+    return (int(a, 16) ^ int(b, 16)).bit_count()
+
+
+@pytest.mark.benchmark(group="random_bytes")
+@pytest.mark.parametrize("size", (16, 64, 1024))
+def test_hamming_distance_bytes_random_bench(benchmark, size):
+    a = random_bytes(size)
+    b = random_bytes(size + 1)[:size]
+    benchmark(hamming_distance_bytes, a, b)
+
+
+@pytest.mark.benchmark(group="random_bytes_stdlib")
+@pytest.mark.parametrize("size", (16, 64, 1024))
+def test_stdlib_bytes_distance_random_bench(benchmark, size):
+    a = random_bytes(size)
+    b = random_bytes(size + 1)[:size]
+    benchmark(stdlib_bytes_distance, a, b)
+
+
+@pytest.mark.benchmark(group="random_hex")
+@pytest.mark.parametrize("size", (16, 64, 1024))
+def test_hamming_distance_string_random_bench(benchmark, size):
+    a = random_bytes(size // 2).hex()
+    b = random_bytes(size // 2 + 1).hex()[:size]
+    benchmark(hamming_distance_string, a, b)
+
+
+@pytest.mark.benchmark(group="random_hex_stdlib")
+@pytest.mark.parametrize("size", (16, 64, 1024))
+def test_stdlib_hex_distance_random_bench(benchmark, size):
+    a = random_bytes(size // 2).hex()
+    b = random_bytes(size // 2 + 1).hex()[:size]
+    benchmark(stdlib_hex_distance, a, b)
+
+
+@pytest.mark.benchmark(group="gil_boundary")
+@pytest.mark.parametrize("size", (16376, 16384, 16392))
+def test_hamming_distance_bytes_gil_boundary_bench(benchmark, size):
+    a = random_bytes(size)
+    b = random_bytes(size + 1)[:size]
+    benchmark(hamming_distance_bytes, a, b)


### PR DESCRIPTION
## Why

The first performance pass made the individual Hamming-distance kernels very fast. Follow-up profiling showed that batch scans and Python wrappers were still spending meaningful time on repeated setup, thread scheduling, and buffer handling.

This PR removes that remaining overhead without changing the public API or results.

## What changed

- **Choose the byte kernel once per batch.** Array scans no longer reload and match the selected algorithm for every record.
- **Use a fast path for 16-byte records.** This common width is handled with two native 64-bit loads and popcounts. Larger fixed-width experiments were slower and were not retained.
- **Start Rayon only when it helps.** Parallel scanning now begins at the measured 5 MiB crossover, avoiding a severe latency cliff on medium batches.
- **Make generic Python buffers cheaper.** `bytearray`, `memoryview`, and other contiguous buffers use a stack-pinned buffer guard instead of boxed `PyBuffer` setup.
- **Tune GIL release paths.** Bytes remain attached until 16 KiB, while immutable strings can release the GIL without copying their contents.
- **Broaden performance coverage.** Criterion and pytest-benchmark now include random inputs, no-match scans, standard-library comparisons, and dispatch boundaries.

## Representative results

These comparisons use a same-state `main` baseline to avoid CPU-frequency differences between benchmark sessions.

| Workload | `main` | This PR | Improvement |
|---|---:|---:|---:|
| Rust 512×16 `all` | 1,049 ns | 449 ns | **57.2%** |
| Rust 512×16 `first`, match last | 912 ns | 402 ns | **55.9%** |
| Rust 16,384×64 `best` | 55.8 µs | 11.0 µs | **80.3%** |
| Rust 16,384×64 `all` | 65.7 µs | 20.4 µs | **69.0%** |
| Python 512×16 `all` | 1,125 ns | 538 ns | **52.2%** |
| Python 16,384×64 `best` | 73.3 µs | 32.0 µs | **56.3%** |
| Python 16,384×64 `all` | 72.2 µs | 30.7 µs | **57.5%** |

Additional isolated measurements show 64-byte `bytearray` calls improving 38.2%, 1 MiB hex calls improving 26.0% by avoiding copies, and the 4 KiB byte boundary improving 26.5%.

## Safety and compatibility

- No public API or result changes.
- Batch ordering and tie behavior remain unchanged.
- Generic buffers are still required to be contiguous and byte-formatted.
- Large calls still release the GIL so other Python threads can run.
- The pinned guard ensures Python’s self-referential `Py_buffer` is never moved after acquisition.

## Testing

- `cargo test --no-default-features` (74 unit tests, 2 doctests)
- `cargo fmt --check`
- `ruff check .`
- `ruff format --check .`
- `python -m pytest -q .` (140 passed, 3 skipped)
- Three complete Criterion passes
- Three complete pytest-benchmark passes

## Follow-up

- #51 tracks the only remaining material opportunities: x86-specific SIMD on real hardware and cross-record SIMD batching.