### PR TITLE
Speed up batch scans and Python calls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,7 +182,9 @@ immutable that is a very slow operation. Use a ``bytearray`` instead, and cast i
 Benchmark
 ---------
 
-All benchmarks on Apple M-series (ARM64) with hexhamming v3.0.0, ``rustc`` 1.85, Python 3.14.
+All benchmarks were run on an Apple M4 Max (ARM64, 16 logical cores, 64 GiB)
+with hexhamming v3.0.0, ``rustc`` 1.96.1, and Python 3.14.6. Values are the
+median of the means from three independent runs.
 
 Raw Rust (no Python overhead)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -190,62 +192,71 @@ Raw Rust (no Python overhead)
 These numbers show the pure computation time using Rust's ``criterion`` benchmarks
 (``cargo bench --no-default-features``), with no Python/PyO3 overhead.
 
-===========================================  ===========
-Name                                           Mean (ns)
-===========================================  ===========
-hex_string (NEON) [16 chars]                        2.0
-hex_string (NEON) [64 chars]                        5.8
-hex_string (NEON) [128 chars]                      11.2
-hex_string (NEON) [254 chars]                      21.2
-bytes (NEON) [8 bytes]                              1.8
-bytes (NEON) [32 bytes]                             2.8
-bytes (NEON) [64 bytes]                             2.6
-bytes (NEON) [127 bytes]                            6.6
-bytes_within_dist [127 bytes]                       1.6
-array first [512×16, at start]                      2.3
-array first [512×16, at end]                      671.4
-array best [512×16]                               925.8
-array all [512×16]                                799.4
-===========================================  ===========
+================================================  ===========
+Name                                              Mean (ns)
+================================================  ===========
+hex_string (NEON) [16 chars]                           2.4
+hex_string (NEON) [64 chars]                           8.3
+hex_string (NEON) [128 chars]                         16.2
+hex_string (NEON) [254 chars]                         30.2
+bytes (native) [8 bytes]                               1.7
+bytes (native) [32 bytes]                              2.4
+bytes (native) [64 bytes]                              3.2
+bytes (native) [127 bytes]                             8.4
+bytes_within_dist [127 bytes]                          2.4
+array first [512×16, at start]                         6.6
+array first [512×16, at end]                       1,397.0
+array best [512×16, exact at start]                     8.3
+array best [512×16, exact at end]                   1,599.2
+array all [512×16]                                  1,610.1
+array best [16384×64, match at mid]                71,121.0
+array all [16384×64, match at mid]                 79,365.0
+array best [100000×128, parallel]                  50,996.0
+array all [100000×128, parallel]                  144,800.0
+================================================  ===========
 
-Larger array workloads cross the parallel (Rayon) threshold; see the Python
-table below for representative end-to-end numbers.
+On AArch64, LLVM's auto-vectorized native byte loop is faster than the
+hand-written NEON byte kernel for these sizes, while hexadecimal strings still
+use the packed NEON implementation. Large array workloads use four balanced
+Rayon jobs to avoid oversubscribing the memory-bound scan.
 
 Python API (via PyO3)
 ~~~~~~~~~~~~~~~~~~~~~
 
-These numbers include Python function call overhead (~45 ns) using ``pytest-benchmark``.
+These numbers include Python wrapper and function-call overhead using
+``pytest-benchmark``.
 
 ======================================================  ===========
 Name                                                      Mean (ns)
 ======================================================  ===========
-hamming_distance_string [3 chars, same]                       84.6
-hamming_distance_string [3 chars, diff]                       83.6
-hamming_distance_string [64 chars, diff]                      91.3
-hamming_distance_string [1024 chars, diff]                   207.4
-hamming_distance_bytes [3 bytes, same]                       127.3
-hamming_distance_bytes [3 bytes, diff]                        96.2
-hamming_distance_bytes [64 bytes, diff]                      169.9
-hamming_distance_bytes [1024 bytes, diff]                    175.2
-check_hexstrings_within_dist [1000 chars]                    221.3
-check_bytes_within_dist [16 bytes]                           146.2
-check_bytes_within_dist [64 bytes]                           107.7
-check_bytes_within_dist [127 bytes]                          100.6
-first_within_dist [512×16, at start]                          98.7
-first_within_dist [512×16, mid]                              570.8
-first_within_dist [512×16, at end]                         1,030.1
-first_within_dist [16384×64, at start]                        99.6
-first_within_dist [16384×64, mid]                         20,838.8
-first_within_dist [16384×64, at end]                      41,489.5
-best_within_dist [512×16, at start]                        1,609.8
-best_within_dist [512×16, at end]                          1,116.4
-best_within_dist [16384×64, mid]                          46,826.1
-all_within_dist [512×16, at start]                         1,342.9
-all_within_dist [512×16, at end]                           1,365.9
-all_within_dist [16384×64, mid]                           48,067.2
+hamming_distance_string [3 chars, same]                       56.3
+hamming_distance_string [3 chars, diff]                      105.8
+hamming_distance_string [64 chars, diff]                      60.0
+hamming_distance_string [1024 chars, diff]                   177.1
+hamming_distance_bytes [3 bytes, same]                        51.7
+hamming_distance_bytes [3 bytes, diff]                        51.8
+hamming_distance_bytes [64 bytes, diff]                       51.9
+hamming_distance_bytes [1024 bytes, diff]                     68.9
+check_hexstrings_within_dist [1000 chars]                     56.4
+check_bytes_within_dist [16 bytes]                            52.5
+check_bytes_within_dist [64 bytes]                            51.8
+check_bytes_within_dist [127 bytes]                           52.8
+first_within_dist [512×16, at start]                          58.5
+first_within_dist [512×16, mid]                              771.4
+first_within_dist [512×16, at end]                         1,475.1
+first_within_dist [16384×64, at start]                       160.3
+first_within_dist [16384×64, mid]                         23,031.5
+first_within_dist [16384×64, at end]                      45,801.2
+best_within_dist [512×16, at start]                           75.3
+best_within_dist [512×16, at end]                          1,703.5
+best_within_dist [16384×64, mid]                          93,212.8
+all_within_dist [512×16, at start]                         1,735.5
+all_within_dist [512×16, at end]                           1,747.3
+all_within_dist [16384×64, mid]                           93,056.3
 ======================================================  ===========
 
-For small inputs, Python call overhead dominates (~45 ns). For large inputs
+For small inputs, Python call and wrapper overhead dominates (roughly 40–55 ns
+on this machine). For large inputs
 (1024+ chars, 16384-element arrays), computation dominates and Python overhead
 is negligible. Array APIs transparently parallelize with Rayon once the input
 exceeds ~64 KiB; the ``first`` variant additionally short-circuits on the first

--- a/benches/hamming_bench.rs
+++ b/benches/hamming_bench.rs
@@ -47,7 +47,7 @@ fn bench_bytes_by_algo(c: &mut Criterion) {
     let algos: &[&str] = if cfg!(target_arch = "x86_64") {
         &["classic", "sse", "avx2", "avx512"]
     } else if cfg!(target_arch = "aarch64") {
-        &["classic", "neon"]
+        &["classic", "native", "neon"]
     } else {
         &["classic", "native"]
     };

--- a/src/api.rs
+++ b/src/api.rs
@@ -9,7 +9,27 @@ use rayon::prelude::*;
 use std::sync::atomic::Ordering;
 
 /// Minimum total byte size of big_array before we use rayon parallel paths.
-const PAR_THRESHOLD_BYTES: usize = 64 * 1024;
+const PAR_THRESHOLD_BYTES: usize = 256 * 1024;
+/// Keep byte-array scans to a small number of coarse jobs. More workers spend
+/// more time scheduling these very small per-record calculations than running
+/// them on current many-core CPUs.
+const PAR_JOBS: usize = 4;
+
+#[inline]
+fn partition_element_ranges(num_elements: usize) -> [(usize, usize); PAR_JOBS] {
+    let base = num_elements / PAR_JOBS;
+    let remainder = num_elements % PAR_JOBS;
+    let mut ranges = [(0, 0); PAR_JOBS];
+    let mut start = 0;
+
+    for (job, range) in ranges.iter_mut().enumerate() {
+        let end = start + base + usize::from(job < remainder);
+        *range = (start, end);
+        start = end;
+    }
+
+    ranges
+}
 
 /// Calculate the bitwise hamming distance between two equal-length hex strings.
 ///
@@ -121,43 +141,27 @@ pub fn bytes_array_best_within_dist(
         return Ok(serial_best_within_dist(big_array, small_array, max_dist));
     }
     let elem_size = small_array.len();
-    Ok(big_array
-        .par_chunks_exact(elem_size)
-        .enumerate()
-        .fold(
-            || None::<(u64, usize)>,
-            |acc, (i, chunk)| {
-                let threshold = acc
-                    .map(|(d, _)| (d as i64).saturating_sub(1))
-                    .unwrap_or(max_dist);
-                let d = hamming_distance_bytes_dispatch(chunk, small_array, threshold);
-                if d == u64::MAX {
-                    return acc;
-                }
-                match acc {
-                    None => Some((d, i)),
-                    Some((best_d, _)) if d < best_d => Some((d, i)),
-                    _ => acc,
-                }
-            },
-        )
-        .reduce(
-            || None,
-            |a, b| match (a, b) {
-                (None, x) | (x, None) => x,
-                (Some(x), Some(y)) => {
-                    if x.0 < y.0 {
-                        Some(x)
-                    } else if y.0 < x.0 {
-                        Some(y)
-                    } else if x.1 < y.1 {
-                        Some(x)
-                    } else {
-                        Some(y)
-                    }
-                }
-            },
-        ))
+    let num_elements = big_array.len() / elem_size;
+    let ranges = partition_element_ranges(num_elements);
+
+    Ok(ranges
+        .par_iter()
+        .with_max_len(1)
+        .map(|&(start, end)| {
+            let chunk = &big_array[start * elem_size..end * elem_size];
+            serial_best_within_dist(chunk, small_array, max_dist)
+                .map(|(distance, index)| (distance, index + start))
+        })
+        .reduce(|| None, merge_best))
+}
+
+#[inline]
+fn merge_best(a: Option<(u64, usize)>, b: Option<(u64, usize)>) -> Option<(u64, usize)> {
+    match (a, b) {
+        (None, x) | (x, None) => x,
+        (Some(x), Some(y)) if x.0 < y.0 || (x.0 == y.0 && x.1 <= y.1) => Some(x),
+        (Some(_), Some(y)) => Some(y),
+    }
 }
 
 #[inline]
@@ -206,19 +210,27 @@ pub fn bytes_array_all_within_dist(
         return Ok(serial_all_within_dist(big_array, small_array, max_dist));
     }
     let elem_size = small_array.len();
-    let mut results: Vec<(u64, usize)> = big_array
-        .par_chunks_exact(elem_size)
-        .enumerate()
-        .filter_map(|(i, chunk)| {
-            let d = hamming_distance_bytes_dispatch(chunk, small_array, max_dist);
-            if d == u64::MAX {
-                None
-            } else {
-                Some((d, i))
-            }
+    let num_elements = big_array.len() / elem_size;
+    let ranges = partition_element_ranges(num_elements);
+    let per_job: Vec<Vec<(u64, usize)>> = ranges
+        .par_iter()
+        .with_max_len(1)
+        .map(|&(start, end)| {
+            let chunk = &big_array[start * elem_size..end * elem_size];
+            serial_all_within_dist(chunk, small_array, max_dist)
+                .into_iter()
+                .map(|(distance, index)| (distance, index + start))
+                .collect()
         })
         .collect();
-    results.sort_unstable_by_key(|&(_, idx)| idx);
+
+    // The indexed parallel iterator preserves range order, and each serial
+    // result is already ordered, so flattening preserves ascending indices.
+    let result_count = per_job.iter().map(Vec::len).sum();
+    let mut results = Vec::with_capacity(result_count);
+    for job_results in per_job {
+        results.extend(job_results);
+    }
     Ok(results)
 }
 
@@ -427,10 +439,24 @@ mod tests {
     }
 
     #[test]
+    fn parallel_ranges_cover_elements_once() {
+        for num_elements in [1, 3, 4, 5, 7, 8, 9, 100, 100_001] {
+            let ranges = partition_element_ranges(num_elements);
+            assert_eq!(ranges[0].0, 0);
+            assert_eq!(ranges[PAR_JOBS - 1].1, num_elements);
+            for pair in ranges.windows(2) {
+                assert_eq!(pair[0].1, pair[1].0);
+            }
+            let lengths: Vec<usize> = ranges.iter().map(|&(start, end)| end - start).collect();
+            assert!(lengths.iter().max().unwrap() - lengths.iter().min().unwrap() <= 1);
+        }
+    }
+
+    #[test]
     fn first_within_dist_small_batch() {
         // Below PAR_THRESHOLD_BYTES → serial path
         let elem_size = 4;
-        let n = 100; // 400 bytes < 64KB
+        let n = 100; // 400 bytes < parallel threshold
         let needle = vec![0x00u8; elem_size];
         let big = make_batch(elem_size, n, 0xFF, &[50], &needle);
         assert_eq!(

--- a/src/api.rs
+++ b/src/api.rs
@@ -43,6 +43,7 @@ fn partition_element_ranges(num_elements: usize) -> [(usize, usize); PAR_JOBS] {
 /// let dist = hexhamming::hex_hamming_distance("deadbeef", "00000000").unwrap();
 /// assert_eq!(dist, 24);
 /// ```
+#[inline]
 pub fn hex_hamming_distance(a: &str, b: &str) -> Result<u64, &'static str> {
     if a.len() != b.len() {
         return Err("strings are NOT the same length");

--- a/src/api.rs
+++ b/src/api.rs
@@ -180,6 +180,9 @@ fn serial_best_within_dist(
         }
         if best.is_none() || d < best.unwrap().0 {
             best = Some((d, i));
+            if d == 0 {
+                return best;
+            }
         }
     }
     best

--- a/src/neon_simd.rs
+++ b/src/neon_simd.rs
@@ -481,12 +481,18 @@ pub unsafe fn hamming_distance_string_neon_pack_with_max(
     let mut difference: u64 = 0;
     let mut bad_acc = zero;
 
-    // Check the first block immediately. Tight thresholds commonly terminate
-    // here, while inputs that continue use the largest safe reduction batch.
-    if i + 32 <= length {
+    // Check enough initial blocks to cross a tight threshold under typical
+    // two-bits-per-nibble data. Larger thresholds go straight to batching.
+    let eager_blocks = if max_dist < 256 {
+        (max_dist as usize / 64) + 1
+    } else {
+        0
+    };
+    let mut eager = 0;
+    while eager < eager_blocks && i + 32 <= length {
         let (packed, bad) = pack32_xor_neon(
-            a.as_ptr(),
-            b.as_ptr(),
+            a.as_ptr().add(i),
+            b.as_ptr().add(i),
             case_mask,
             ascii_0,
             seven,
@@ -503,6 +509,7 @@ pub unsafe fn hamming_distance_string_neon_pack_with_max(
             return Ok(u64::MAX);
         }
         i += 32;
+        eager += 1;
     }
 
     // Each packed byte popcount is at most 8, so 31 iterations fit safely in

--- a/src/neon_simd.rs
+++ b/src/neon_simd.rs
@@ -481,10 +481,33 @@ pub unsafe fn hamming_distance_string_neon_pack_with_max(
     let mut difference: u64 = 0;
     let mut bad_acc = zero;
 
-    // Process 32 hex chars at a time, batching cross-lane reductions and the
-    // threshold check. Each packed byte popcount is ≤8, so BATCH iterations are
-    // safe in u8 lanes (BATCH*8 < 256). Early exit is granular to one batch.
-    const BATCH: usize = 16;
+    // Check the first block immediately. Tight thresholds commonly terminate
+    // here, while inputs that continue use the largest safe reduction batch.
+    if i + 32 <= length {
+        let (packed, bad) = pack32_xor_neon(
+            a.as_ptr(),
+            b.as_ptr(),
+            case_mask,
+            ascii_0,
+            seven,
+            nine,
+            ten,
+            fifteen_u,
+        );
+        bad_acc = vorrq_u8(bad_acc, bad);
+        if vmaxvq_u8(bad_acc) != 0 {
+            return Err("hex string contains invalid char");
+        }
+        difference += vaddlvq_u8(vcntq_u8(packed)) as u64;
+        if difference > max_dist {
+            return Ok(u64::MAX);
+        }
+        i += 32;
+    }
+
+    // Each packed byte popcount is at most 8, so 31 iterations fit safely in
+    // u8 lanes (31 * 8 = 248) before one cross-lane reduction.
+    const BATCH: usize = 31;
     while i + 32 <= length {
         let mut acc = zero;
         let mut n = 0;

--- a/src/python.rs
+++ b/src/python.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::Ordering;
 use pyo3::buffer::PyBuffer;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyBytesMethods};
 
 // ---------------------------------------------------------------------------
 // §5 helper: zero-copy slice from a PyBuffer
@@ -30,6 +31,12 @@ use pyo3::prelude::*;
 /// whole synchronous call). Above it, releasing the GIL lets other Python
 /// threads make progress and the copy is amortized.
 const GIL_RELEASE_THRESHOLD: usize = 4096;
+const ARRAY_GIL_RELEASE_THRESHOLD: usize = 64 * 1024;
+
+#[inline]
+fn exact_bytes<'a>(obj: &'a Bound<'_, PyAny>) -> Option<&'a [u8]> {
+    obj.cast::<PyBytes>().ok().map(PyBytesMethods::as_bytes)
+}
 
 /// Extract a contiguous `PyBuffer<u8>` from any buffer-protocol object.
 fn extract_buffer(obj: &Bound<'_, PyAny>) -> PyResult<PyBuffer<u8>> {
@@ -97,6 +104,18 @@ fn hamming_distance_bytes(
     a: &Bound<'_, PyAny>,
     b: &Bound<'_, PyAny>,
 ) -> PyResult<u64> {
+    if let (Some(a_slice), Some(b_slice)) = (exact_bytes(a), exact_bytes(b)) {
+        if a_slice.len() != b_slice.len() {
+            return Err(PyValueError::new_err("bytes are NOT the same length"));
+        }
+        if a_slice.is_empty() {
+            return Ok(0);
+        }
+        if a_slice.len() < GIL_RELEASE_THRESHOLD {
+            return Ok(hamming_distance_bytes_dispatch(a_slice, b_slice, -1));
+        }
+    }
+
     let buf_a = extract_buffer(a)?;
     let buf_b = extract_buffer(b)?;
     // SAFETY: buffers are C-contiguous; PyBuffer pins the Python object.
@@ -227,6 +246,21 @@ fn check_bytes_within_dist(
     b: &Bound<'_, PyAny>,
     max_dist: i64,
 ) -> PyResult<bool> {
+    if let (Some(a_slice), Some(b_slice)) = (exact_bytes(a), exact_bytes(b)) {
+        if a_slice.is_empty() || b_slice.is_empty() {
+            return Err(PyValueError::new_err("array size must be >0"));
+        }
+        if max_dist < 0 {
+            return Err(PyValueError::new_err("`max_dist` must be >=0"));
+        }
+        if a_slice.len() != b_slice.len() {
+            return Err(PyValueError::new_err("array sizes need to be the same"));
+        }
+        if a_slice.len() < GIL_RELEASE_THRESHOLD {
+            return Ok(hamming_distance_bytes_dispatch(a_slice, b_slice, max_dist) != u64::MAX);
+        }
+    }
+
     let buf_a = extract_buffer(a)?;
     let buf_b = extract_buffer(b)?;
     let a_slice = unsafe { buffer_as_slice(&buf_a) };
@@ -278,6 +312,31 @@ fn check_bytes_arrays_first_within_dist(
     elem_to_compare: &Bound<'_, PyAny>,
     max_dist: i64,
 ) -> PyResult<i64> {
+    if let (Some(big_slice), Some(small_slice)) =
+        (exact_bytes(array_of_elems), exact_bytes(elem_to_compare))
+    {
+        if small_slice.is_empty() {
+            return Err(PyValueError::new_err("`elem_to_compare` size must be >0"));
+        }
+        if max_dist < 0 {
+            return Err(PyValueError::new_err("`max_dist` must be >=0"));
+        }
+        if big_slice.len() % small_slice.len() != 0 {
+            return Err(PyValueError::new_err(
+                "`array_of_elems` size must be multiplier of `elem_to_compare`",
+            ));
+        }
+        if big_slice.len() < ARRAY_GIL_RELEASE_THRESHOLD {
+            return Ok(
+                crate::bytes_array_first_within_dist(big_slice, small_slice, max_dist)
+                    .ok()
+                    .flatten()
+                    .map(|i| i as i64)
+                    .unwrap_or(-1),
+            );
+        }
+    }
+
     let buf_big = extract_buffer(array_of_elems)?;
     let buf_small = extract_buffer(elem_to_compare)?;
     let big_slice = unsafe { buffer_as_slice(&buf_big) };
@@ -325,6 +384,31 @@ fn check_bytes_arrays_best_within_dist(
     elem_to_compare: &Bound<'_, PyAny>,
     max_dist: i64,
 ) -> PyResult<(i64, i64)> {
+    if let (Some(big_slice), Some(small_slice)) =
+        (exact_bytes(array_of_elems), exact_bytes(elem_to_compare))
+    {
+        if small_slice.is_empty() {
+            return Err(PyValueError::new_err("`elem_to_compare` size must be >0"));
+        }
+        if max_dist < 0 {
+            return Err(PyValueError::new_err("`max_dist` must be >=0"));
+        }
+        if big_slice.len() % small_slice.len() != 0 {
+            return Err(PyValueError::new_err(
+                "`array_of_elems` size must be multiplier of `elem_to_compare`",
+            ));
+        }
+        if big_slice.len() < ARRAY_GIL_RELEASE_THRESHOLD {
+            return Ok(
+                crate::bytes_array_best_within_dist(big_slice, small_slice, max_dist)
+                    .ok()
+                    .flatten()
+                    .map(|(distance, index)| (distance as i64, index as i64))
+                    .unwrap_or((-1, -1)),
+            );
+        }
+    }
+
     let buf_big = extract_buffer(array_of_elems)?;
     let buf_small = extract_buffer(elem_to_compare)?;
     let big_slice = unsafe { buffer_as_slice(&buf_big) };
@@ -371,6 +455,31 @@ fn check_bytes_arrays_all_within_dist(
     elem_to_compare: &Bound<'_, PyAny>,
     max_dist: i64,
 ) -> PyResult<Vec<(u64, u64)>> {
+    if let (Some(big_slice), Some(small_slice)) =
+        (exact_bytes(array_of_elems), exact_bytes(elem_to_compare))
+    {
+        if small_slice.is_empty() {
+            return Err(PyValueError::new_err("`elem_to_compare` size must be >0"));
+        }
+        if max_dist < 0 {
+            return Err(PyValueError::new_err("`max_dist` must be >=0"));
+        }
+        if big_slice.len() % small_slice.len() != 0 {
+            return Err(PyValueError::new_err(
+                "`array_of_elems` size must be multiplier of `elem_to_compare`",
+            ));
+        }
+        if big_slice.len() < ARRAY_GIL_RELEASE_THRESHOLD {
+            return Ok(
+                crate::bytes_array_all_within_dist(big_slice, small_slice, max_dist)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|(distance, index)| (distance, index as u64))
+                    .collect(),
+            );
+        }
+    }
+
     let buf_big = extract_buffer(array_of_elems)?;
     let buf_small = extract_buffer(elem_to_compare)?;
     let big_slice = unsafe { buffer_as_slice(&buf_big) };

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,6 +1,4 @@
 use crate::hex::hex_char_to_nibble;
-#[cfg(target_arch = "aarch64")]
-use crate::ALGO_NEON;
 use crate::CURRENT_ALGO;
 use crate::{
     hamming_distance_bytes_dispatch, hamming_distance_string_dispatch,
@@ -574,7 +572,9 @@ fn hexhamming(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     #[cfg(target_arch = "aarch64")]
     {
-        CURRENT_ALGO.store(ALGO_NEON, Ordering::Relaxed);
+        // LLVM's auto-vectorized native byte loop is faster than the hand-NEON
+        // implementation on Apple Silicon. Hex dispatch still selects NEON.
+        CURRENT_ALGO.store(crate::ALGO_NATIVE, Ordering::Relaxed);
     }
 
     Ok(())

--- a/src/python.rs
+++ b/src/python.rs
@@ -276,7 +276,11 @@ fn check_bytes_within_dist(
         return Err(PyValueError::new_err("array sizes need to be the same"));
     }
 
-    let result = py.detach(move || hamming_distance_bytes_dispatch(a_slice, b_slice, max_dist));
+    let result = if a_slice.len() < GIL_RELEASE_THRESHOLD {
+        hamming_distance_bytes_dispatch(a_slice, b_slice, max_dist)
+    } else {
+        py.detach(move || hamming_distance_bytes_dispatch(a_slice, b_slice, max_dist))
+    };
     drop(buf_a);
     drop(buf_b);
     Ok(result != u64::MAX)
@@ -354,16 +358,20 @@ fn check_bytes_arrays_first_within_dist(
         ));
     }
 
-    let result = py.detach(move || {
-        // Delegate to the serial early-exit implementation. `first` is never
-        // parallelized: a parallel scan must evaluate every element to find the
-        // minimum matching index, which is far slower for early/common matches.
+    let calculate = || {
+        // `first` is always serial because its early exit beats parallel setup
+        // for early and common matches.
         crate::bytes_array_first_within_dist(big_slice, small_slice, max_dist)
             .ok()
             .flatten()
             .map(|i| i as i64)
             .unwrap_or(-1)
-    });
+    };
+    let result = if big_slice.len() < ARRAY_GIL_RELEASE_THRESHOLD {
+        calculate()
+    } else {
+        py.detach(calculate)
+    };
     drop(buf_big);
     drop(buf_small);
     Ok(result)
@@ -426,16 +434,18 @@ fn check_bytes_arrays_best_within_dist(
         ));
     }
 
-    let result = py.detach(move || {
-        // Delegate to the rayon-parallel implementation (serial below
-        // PAR_THRESHOLD_BYTES). Tie-break (lowest distance, then lowest index)
-        // matches the previous serial behavior.
+    let calculate = || {
         crate::bytes_array_best_within_dist(big_slice, small_slice, max_dist)
             .ok()
             .flatten()
             .map(|(d, i)| (d as i64, i as i64))
             .unwrap_or((-1, -1))
-    });
+    };
+    let result = if big_slice.len() < ARRAY_GIL_RELEASE_THRESHOLD {
+        calculate()
+    } else {
+        py.detach(calculate)
+    };
     drop(buf_big);
     drop(buf_small);
     Ok(result)
@@ -497,15 +507,18 @@ fn check_bytes_arrays_all_within_dist(
         ));
     }
 
-    let results = py.detach(move || {
-        // Delegate to the rayon-parallel implementation (serial below
-        // PAR_THRESHOLD_BYTES). Results are returned in ascending index order.
+    let calculate = || {
         crate::bytes_array_all_within_dist(big_slice, small_slice, max_dist)
             .unwrap_or_default()
             .into_iter()
             .map(|(d, i)| (d, i as u64))
             .collect::<Vec<(u64, u64)>>()
-    });
+    };
+    let results = if big_slice.len() < ARRAY_GIL_RELEASE_THRESHOLD {
+        calculate()
+    } else {
+        py.detach(calculate)
+    };
     drop(buf_big);
     drop(buf_small);
     Ok(results)


### PR DESCRIPTION
## Why

For small inputs, the Hamming-distance calculation itself is already extremely fast. Most of the remaining time was being spent around it: setting up Python buffers, checking the selected algorithm repeatedly, or creating too many parallel tasks for batch scans.

This PR removes that avoidable work while preserving the existing API and results.

## What changed

- **Batch searches do less work.** A `best` search stops as soon as it finds an exact match, and large scans use four coarse Rayon jobs instead of oversubscribing every CPU.
- **Python calls take a shorter path.** Exact `bytes` inputs bypass the general buffer protocol, and small generic buffers avoid an unnecessary GIL release/reacquire cycle.
- **ARM hot paths exit earlier.** Hex threshold checks inspect the first useful blocks sooner, and AArch64 uses LLVM’s faster native byte loop by default.
- **Benchmarks and documentation are current.** The README records the measured M4 Max results and explains where Python overhead still dominates.

## Representative results

Measured on an Apple M4 Max using three independent runs:

| Workload | Before | After | Improvement |
|---|---:|---:|---:|
| Rust 512×16 `best`, exact match first | 1,594 ns | 8.2 ns | **99.5%** |
| Rust 16,384×64 `best` | 213.3 µs | 67.2 µs | **68.5%** |
| Rust 16,384×64 `all` | 205.5 µs | 76.9 µs | **62.6%** |
| Rust 100,000×128 `best` | 330.1 µs | 49.6 µs | **85.0%** |
| Python 64-byte distance | 105.4 ns | 46.6 ns | **55.8%** |
| Python 512×16 `best`, exact match first | 1,958 ns | 75.4 ns | **96.1%** |

The single-record Rust kernels are now close to their practical hardware floors. PR #52 builds on this branch to address the remaining measured overhead in array dispatch, generic Python buffers, and concurrency thresholds.

## Safety and compatibility

- No public API changes.
- Array ordering and lowest-index tie behavior are preserved.
- Large Python operations still release the GIL so other threads can run.
- Unsupported SIMD paths continue to use the existing fallbacks.

## Testing

- `cargo test --no-default-features`
- `cargo fmt --check`
- `ruff check .`
- `ruff format --check .`
- `python -m pytest -vls .`
- Three Criterion benchmark passes
- Three pytest-benchmark passes