### PR TITLE
Speed up AVX-512 byte and fixed-width array scans

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Lastly, I wanted to minimize dependencies, meaning you do not need to install
 As of v3.0.0, ``hexhamming`` is written in Rust using `PyO3 <https://pyo3.rs>`_
 and `maturin <https://www.maturin.rs>`_, providing memory safety, GIL release
 during computation, and free-threaded Python support while maintaining the same
-SIMD-accelerated performance (SSE4.1, AVX2, NEON).
+SIMD-accelerated performance (SSE4.1, AVX2, AVX-512 BITALG, NEON).
 
 Installation
 -------------
@@ -194,6 +194,49 @@ times on each representative x86 machine:
 The script records CPU features and tool versions alongside Criterion output
 and end-to-end Python benchmark JSON. Compare results only between runs from
 the same machine.
+
+AVX-512 results
+~~~~~~~~~~~~~~~~
+
+Three-run medians on a Google Cloud ``c4-standard-4`` with an Intel Xeon
+Platinum 8581C (Emerald Rapids):
+
+.. list-table::
+   :header-rows: 1
+
+   * - Workload
+     - Before
+     - After
+     - Speedup
+   * - Python 1024x16 first, random/no-match
+     - 3.222 us
+     - 0.679 us
+     - 4.75x
+   * - Python 1024x16 best, random/no-match
+     - 3.720 us
+     - 0.651 us
+     - 5.72x
+   * - Python 1024x16 all, random/no-match
+     - 3.466 us
+     - 0.710 us
+     - 4.88x
+   * - Python 1024x32 first, random/no-match
+     - 3.199 us
+     - 1.278 us
+     - 2.50x
+   * - Python 1024x32 best, random/no-match
+     - 3.729 us
+     - 1.383 us
+     - 2.70x
+   * - Python 1024x32 all, random/no-match
+     - 3.445 us
+     - 1.377 us
+     - 2.50x
+
+The AVX-512 byte kernel also uses masked loads below 64 bytes, improving the
+measured 16-, 32-, 48-, and 63-byte Rust paths by 33%, 50%, 70%, and 194%
+respectively. AVX2-only tuning remains hardware-dependent and should be
+measured separately on a machine without AVX-512.
 
 All benchmarks were run on an Apple M4 Max (ARM64, 16 logical cores, 64 GiB)
 with hexhamming v3.0.0, ``rustc`` 1.97.1, and Python 3.14.6. Values are the

--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,19 @@ immutable that is a very slow operation. Use a ``bytearray`` instead, and cast i
 Benchmark
 ---------
 
+For repeatable AVX2 and AVX-512 investigations, run the same checkout three
+times on each representative x86 machine:
+
+.. code-block:: bash
+
+    scripts/benchmark_x86.sh before
+    # Apply the candidate optimization, then:
+    scripts/benchmark_x86.sh after
+
+The script records CPU features and tool versions alongside Criterion output
+and end-to-end Python benchmark JSON. Compare results only between runs from
+the same machine.
+
 All benchmarks were run on an Apple M4 Max (ARM64, 16 logical cores, 64 GiB)
 with hexhamming v3.0.0, ``rustc`` 1.97.1, and Python 3.14.6. Values are the
 median of the means from three independent runs.

--- a/benches/hamming_bench.rs
+++ b/benches/hamming_bench.rs
@@ -27,7 +27,7 @@ fn pseudo_random_bytes(len: usize, seed: u64) -> Vec<u8> {
 /// Benchmark hex hamming distance across all available algorithms
 fn bench_hex_by_algo(c: &mut Criterion) {
     let algos: &[&str] = if cfg!(target_arch = "x86_64") {
-        &["classic", "native", "sse", "avx2", "avx512"]
+        &["classic", "sse", "avx2", "avx512"]
     } else if cfg!(target_arch = "aarch64") {
         &["classic", "neon"]
     } else {
@@ -58,7 +58,7 @@ fn bench_hex_by_algo(c: &mut Criterion) {
 /// Benchmark bytes hamming distance across all available algorithms
 fn bench_bytes_by_algo(c: &mut Criterion) {
     let algos: &[&str] = if cfg!(target_arch = "x86_64") {
-        &["classic", "sse", "avx2", "avx512"]
+        &["classic", "native", "sse", "avx2", "avx512"]
     } else if cfg!(target_arch = "aarch64") {
         &["classic", "native", "neon"]
     } else {

--- a/benches/hamming_bench.rs
+++ b/benches/hamming_bench.rs
@@ -358,6 +358,83 @@ fn bench_fixed_width_array_matrix(c: &mut Criterion) {
     }
 }
 
+/// A/B comparison between the algorithm paths that DO and DO NOT engage the
+/// fixed-width cross-record scanner. `select_array_scanner_for_width` opts in
+/// only for `native`/`neon` on aarch64 and `native`/`avx512` on x86; other
+/// algorithms fall back to the per-record byte kernel. Running the same
+/// scenarios under both toggles measures the end-to-end dispatch alternatives.
+///
+/// Only runs on architectures where a fixed-width scanner is available.
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+fn bench_fixed_width_scanner_vs_kernel(c: &mut Criterion) {
+    // The x86 comparison includes both cross-record batching and the wider
+    // AVX-512 BITALG popcount; it is an end-to-end comparison against the
+    // narrower AVX2 per-record fallback, not an isolated batching benchmark.
+    let pairs: &[(&str, &str)] = if cfg!(target_arch = "x86_64") {
+        &[("avx512", "avx2")]
+    } else {
+        &[("native", "classic")]
+    };
+
+    for &(scanner_algo, kernel_algo) in pairs {
+        let scanner_ok = set_algorithm(scanner_algo).is_ok();
+        set_algorithm("native").ok();
+        let kernel_ok = set_algorithm(kernel_algo).is_ok();
+        set_algorithm("native").ok();
+        if !scanner_ok || !kernel_ok {
+            continue;
+        }
+
+        for &(role, algo) in &[("scanner", scanner_algo), ("kernel", kernel_algo)] {
+            if set_algorithm(algo).is_err() {
+                continue;
+            }
+            let mut group = c.benchmark_group(format!(
+                "array_scanner/{scanner_algo}_vs_{kernel_algo}/{role}"
+            ));
+            for &width in &[16usize, 32] {
+                // Same random-no-match scenario as the C4 baseline (see the
+                // catalog benchmarks in `array_api/512x16_random_no_match`) to
+                // allow before/after comparison at that data point.
+                for &count in &[512usize, 1024] {
+                    let small = pseudo_random_bytes(width, 0x51 + width as u64);
+                    let big = pseudo_random_bytes(count * width, 0xA1 + width as u64);
+                    group.bench_function(format!("{width}byte/{count}/first"), |bencher| {
+                        bencher.iter(|| {
+                            bytes_array_first_within_dist(
+                                black_box(&big),
+                                black_box(&small),
+                                black_box(0),
+                            )
+                        })
+                    });
+                    group.bench_function(format!("{width}byte/{count}/best"), |bencher| {
+                        bencher.iter(|| {
+                            bytes_array_best_within_dist(
+                                black_box(&big),
+                                black_box(&small),
+                                black_box(0),
+                            )
+                        })
+                    });
+                    group.bench_function(format!("{width}byte/{count}/all"), |bencher| {
+                        bencher.iter(|| {
+                            bytes_array_all_within_dist(
+                                black_box(&big),
+                                black_box(&small),
+                                black_box(0),
+                            )
+                        })
+                    });
+                }
+            }
+            group.finish();
+        }
+    }
+
+    set_algorithm("native").ok();
+}
+
 fn bench_fixed_width_parallel_crossover(c: &mut Criterion) {
     const PAR_THRESHOLDS: [(&str, usize); 2] = [
         ("legacy", 5 * 1024 * 1024),
@@ -428,10 +505,23 @@ criterion_group!(
     bench_array_api,
     bench_array_random_and_boundaries,
     bench_fixed_width_array_matrix,
+    bench_fixed_width_scanner_vs_kernel,
     bench_fixed_width_parallel_crossover,
     bench_hex_string_pack
 );
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(target_arch = "x86_64")]
+criterion_group!(
+    benches,
+    bench_hex_by_algo,
+    bench_bytes_by_algo,
+    bench_bytes_within_dist,
+    bench_array_api,
+    bench_array_random_and_boundaries,
+    bench_fixed_width_array_matrix,
+    bench_fixed_width_scanner_vs_kernel,
+    bench_fixed_width_parallel_crossover
+);
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
 criterion_group!(
     benches,
     bench_hex_by_algo,

--- a/benches/hamming_bench.rs
+++ b/benches/hamming_bench.rs
@@ -9,7 +9,7 @@ use hexhamming::hex_hamming_distance_pack;
 
 // Hex sizes are character counts; byte sizes are the corresponding decoded lengths.
 const HEX_SIZES: [usize; 5] = [16, 32, 64, 128, 254];
-const BYTE_SIZES: [usize; 8] = [8, 16, 32, 64, 127, 128, 256, 512];
+const BYTE_SIZES: [usize; 12] = [8, 16, 32, 48, 63, 64, 65, 96, 127, 128, 256, 512];
 
 fn pseudo_random_bytes(len: usize, seed: u64) -> Vec<u8> {
     let mut state = seed;
@@ -27,7 +27,7 @@ fn pseudo_random_bytes(len: usize, seed: u64) -> Vec<u8> {
 /// Benchmark hex hamming distance across all available algorithms
 fn bench_hex_by_algo(c: &mut Criterion) {
     let algos: &[&str] = if cfg!(target_arch = "x86_64") {
-        &["classic", "sse", "avx2", "avx512"]
+        &["classic", "native", "sse", "avx2", "avx512"]
     } else if cfg!(target_arch = "aarch64") {
         &["classic", "neon"]
     } else {

--- a/scripts/benchmark_x86.sh
+++ b/scripts/benchmark_x86.sh
@@ -8,6 +8,7 @@ fi
 
 label="${1:-working-tree}"
 output_dir="${2:-benchmark-results/${label}}"
+rust_filter="${3:-}"
 mkdir -p "${output_dir}"
 
 {
@@ -29,17 +30,27 @@ python3 -m pip install --quiet .
 
 for run in 1 2 3; do
     echo "Rust benchmark run ${run}/3"
-    cargo bench --bench hamming_bench -- \
-        --noplot \
-        --save-baseline "${label}-rust-${run}" \
-        2>&1 | tee "${output_dir}/criterion-${run}.txt"
+    if [[ -n "${rust_filter}" ]]; then
+        cargo bench --bench hamming_bench -- \
+            "${rust_filter}" \
+            --noplot \
+            --save-baseline "${label}-rust-${run}" \
+            2>&1 | tee "${output_dir}/criterion-${run}.txt"
+    else
+        cargo bench --bench hamming_bench -- \
+            --noplot \
+            --save-baseline "${label}-rust-${run}" \
+            2>&1 | tee "${output_dir}/criterion-${run}.txt"
+    fi
 
-    echo "Python benchmark run ${run}/3"
-    python3 -m pytest test/ \
-        -k bench \
-        --benchmark-only \
-        --benchmark-disable-gc \
-        --benchmark-json="${output_dir}/python-${run}.json"
+    if [[ "${SKIP_PYTHON:-0}" != "1" ]]; then
+        echo "Python benchmark run ${run}/3"
+        python3 -m pytest test/ \
+            -k bench \
+            --benchmark-only \
+            --benchmark-disable-gc \
+            --benchmark-json="${output_dir}/python-${run}.json"
+    fi
 done
 
 echo "Results written to ${output_dir}"

--- a/scripts/benchmark_x86.sh
+++ b/scripts/benchmark_x86.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -m)" != "x86_64" ]]; then
+    echo "error: x86 SIMD benchmarks require an x86_64 machine" >&2
+    exit 1
+fi
+
+label="${1:-working-tree}"
+output_dir="${2:-benchmark-results/${label}}"
+mkdir -p "${output_dir}"
+
+{
+    echo "label=${label}"
+    echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "kernel=$(uname -a)"
+    echo "rustc=$(rustc --version)"
+    echo "cargo=$(cargo --version)"
+    echo "python=$(python3 --version 2>&1)"
+    if command -v lscpu >/dev/null 2>&1; then
+        lscpu
+    elif command -v sysctl >/dev/null 2>&1; then
+        sysctl -a 2>/dev/null | grep -E 'machdep.cpu.(brand_string|features|leaf7_features)'
+    fi
+} >"${output_dir}/system.txt"
+
+python3 -m pip install --quiet pytest pytest-benchmark
+python3 -m pip install --quiet .
+
+for run in 1 2 3; do
+    echo "Rust benchmark run ${run}/3"
+    cargo bench --bench hamming_bench -- \
+        --noplot \
+        --save-baseline "${label}-rust-${run}" \
+        2>&1 | tee "${output_dir}/criterion-${run}.txt"
+
+    echo "Python benchmark run ${run}/3"
+    python3 -m pytest test/ \
+        -k bench \
+        --benchmark-only \
+        --benchmark-disable-gc \
+        --benchmark-json="${output_dir}/python-${run}.json"
+done
+
+echo "Results written to ${output_dir}"

--- a/src/api.rs
+++ b/src/api.rs
@@ -54,7 +54,38 @@ fn select_array_scanner_for_width(width: usize) -> Option<ArrayScanner> {
         };
     }
 
-    #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(target_arch = "x86_64")]
+    {
+        // Only opt in to the AVX-512 cross-record scanners when the user
+        // hasn't explicitly requested a narrower or scalar backend, and only
+        // when the host actually supports the required feature set. This
+        // preserves observable behavior on hosts without AVX-512 BITALG and
+        // for callers that explicitly set "classic"/"sse"/"avx2".
+        let algo = CURRENT_ALGO.load(Ordering::Relaxed);
+        if (algo == ALGO_NATIVE || algo == ALGO_AVX512)
+            && is_x86_feature_detected!("avx512f")
+            && is_x86_feature_detected!("avx512bw")
+            && is_x86_feature_detected!("avx512bitalg")
+        {
+            return match width {
+                16 => Some(ArrayScanner {
+                    first: crate::x86_simd::array_first_avx512_16_dispatch,
+                    best: crate::x86_simd::array_best_avx512_16_dispatch,
+                    all: crate::x86_simd::array_all_avx512_16_dispatch,
+                }),
+                32 => Some(ArrayScanner {
+                    first: crate::x86_simd::array_first_avx512_32_dispatch,
+                    best: crate::x86_simd::array_best_avx512_32_dispatch,
+                    all: crate::x86_simd::array_all_avx512_32_dispatch,
+                }),
+                _ => None,
+            };
+        }
+        let _ = width;
+        None
+    }
+
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
     {
         let _ = width;
         None

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -511,8 +511,22 @@ fn array_oracle(
 
 #[test]
 fn test_fixed_width_array_scanners_match_randomized_oracle() {
-    for algorithm in ["native", "classic"] {
-        crate::set_algorithm(algorithm).unwrap();
+    // On x86 the AVX-512 cross-record scanners are only reachable when the
+    // active algorithm is `native` or `avx512`, so iterate through both to
+    // exercise the specialized (widths 16 & 32) and the generic paths. On
+    // aarch64 the same iteration covers the NEON fixed-width scanners and
+    // the scalar fallback. `set_algorithm` returns `Err` when the CPU lacks
+    // the requested extension, and we silently skip that iteration so this
+    // test remains portable.
+    let algorithms: &[&str] = if cfg!(target_arch = "x86_64") {
+        &["native", "avx512", "classic"]
+    } else {
+        &["native", "classic"]
+    };
+    for &algorithm in algorithms {
+        if crate::set_algorithm(algorithm).is_err() {
+            continue;
+        }
         for &width in &[1usize, 3, 7, 15, 16, 17, 31, 32, 33] {
             let count = 37;
             let mut state = 0xA5A5_1234_5678_9ABCu64 ^ width as u64;

--- a/src/x86_simd.rs
+++ b/src/x86_simd.rs
@@ -1453,9 +1453,17 @@ unsafe fn array_first_avx512<const WIDTH: usize>(
     single: unsafe fn(*const u8, *const u8) -> u64,
 ) -> Option<usize> {
     let count = big_array.len() / WIDTH;
-    let mut index = 0;
     let big_ptr = big_array.as_ptr();
     let query_ptr = small_array.as_ptr();
+    if count == 0 {
+        return None;
+    }
+
+    let first_distance = single(big_ptr, query_ptr);
+    if within_fixed_threshold(first_distance, max_dist) {
+        return Some(0);
+    }
+    let mut index = 1;
 
     while index + 4 <= count {
         let distances = batch4(big_ptr.add(index * WIDTH), query_ptr);
@@ -1491,10 +1499,18 @@ unsafe fn array_best_avx512<const WIDTH: usize>(
     single: unsafe fn(*const u8, *const u8) -> u64,
 ) -> Option<(u64, usize)> {
     let count = big_array.len() / WIDTH;
-    let mut best: Option<(u64, usize)> = None;
-    let mut index = 0;
     let big_ptr = big_array.as_ptr();
     let query_ptr = small_array.as_ptr();
+    if count == 0 {
+        return None;
+    }
+
+    let first_distance = single(big_ptr, query_ptr);
+    let mut best = within_fixed_threshold(first_distance, max_dist).then_some((first_distance, 0));
+    if first_distance == 0 {
+        return best;
+    }
+    let mut index = 1;
 
     while index + 4 <= count {
         let distances = batch4(big_ptr.add(index * WIDTH), query_ptr);

--- a/src/x86_simd.rs
+++ b/src/x86_simd.rs
@@ -1292,6 +1292,458 @@ pub unsafe fn hamming_distance_string_avx512_with_max(
     }
 }
 
+// -----------------------------------------------------------------------------
+// AVX-512 BITALG cross-record scanners for fixed-width catalogs (widths 16, 32).
+//
+// Modeled on the NEON `array_first_neon` / `array_best_neon` / `array_all_neon`
+// helpers in `neon_simd.rs`. The key insight: a 512-bit ZMM register can hold
+// four 16-byte records or two 32-byte records. By broadcasting the query into
+// the same register, one XOR + VPOPCNTB + VPSADBW pass yields per-record
+// Hamming distances for a whole batch. This trades the NEON pattern of four
+// independent 128-bit ops (four `hamming_distance_neon_fixed` calls) for a
+// single wider vector op per batch of four records.
+//
+// Semantic invariants preserved from the NEON scanners:
+//   * `first` returns the lowest matching index and short-circuits on match.
+//   * `best` returns (distance, index) with the lowest distance, lowest index
+//     on ties, and short-circuits when it observes an exact match (d == 0).
+//   * `all` returns matches in ascending index order.
+//   * `max_dist < 0` disables the threshold check.
+//   * The tail (records not divisible by four) uses the same fixed-width
+//     kernel — bitwise identical to the batch result for a single record.
+// -----------------------------------------------------------------------------
+
+/// Compute Hamming distance between a single 16-byte record and query using
+/// scalar POPCNT. Cheap enough for the tail path; the batch path is where the
+/// AVX-512 win comes from.
+///
+/// # Safety
+/// `record` and `query` must each be valid for 16 readable bytes.
+#[inline(always)]
+unsafe fn hamming_distance_avx512_fixed16(record: *const u8, query: *const u8) -> u64 {
+    let ra = core::ptr::read_unaligned(record as *const u64);
+    let rb = core::ptr::read_unaligned(record.add(8) as *const u64);
+    let qa = core::ptr::read_unaligned(query as *const u64);
+    let qb = core::ptr::read_unaligned(query.add(8) as *const u64);
+    (ra ^ qa).count_ones() as u64 + (rb ^ qb).count_ones() as u64
+}
+
+/// Compute Hamming distance between a single 32-byte record and query using
+/// scalar POPCNT.
+///
+/// # Safety
+/// `record` and `query` must each be valid for 32 readable bytes.
+#[inline(always)]
+unsafe fn hamming_distance_avx512_fixed32(record: *const u8, query: *const u8) -> u64 {
+    let r0 = core::ptr::read_unaligned(record as *const u64);
+    let r1 = core::ptr::read_unaligned(record.add(8) as *const u64);
+    let r2 = core::ptr::read_unaligned(record.add(16) as *const u64);
+    let r3 = core::ptr::read_unaligned(record.add(24) as *const u64);
+    let q0 = core::ptr::read_unaligned(query as *const u64);
+    let q1 = core::ptr::read_unaligned(query.add(8) as *const u64);
+    let q2 = core::ptr::read_unaligned(query.add(16) as *const u64);
+    let q3 = core::ptr::read_unaligned(query.add(24) as *const u64);
+    (r0 ^ q0).count_ones() as u64
+        + (r1 ^ q1).count_ones() as u64
+        + (r2 ^ q2).count_ones() as u64
+        + (r3 ^ q3).count_ones() as u64
+}
+
+/// Compute four Hamming distances (four 16-byte records vs one 16-byte query)
+/// in a single AVX-512 pass.
+///
+/// Pipeline:
+///   1. Broadcast the 16-byte query to all four 128-bit lanes of a ZMM.
+///   2. Load 64 bytes = four contiguous records into a ZMM.
+///   3. XOR + `_mm512_popcnt_epi8` for per-byte popcount.
+///   4. `_mm512_sad_epu8` sums each 8-byte lane; a 16-byte record spans two
+///      adjacent 8-byte SAD lanes, so pair-sum them scalar-side.
+///
+/// # Safety
+/// `records` must be valid for 64 readable bytes and `query` must be valid for
+/// 16 readable bytes. Caller must ensure the CPU supports the target features
+/// (`avx512f`, `avx512bw`, `avx512bitalg`) — the dispatcher does this via
+/// `is_x86_feature_detected!`.
+#[inline]
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512bitalg")]
+unsafe fn hamming_distance_avx512_fixed4_w16(records: *const u8, query: *const u8) -> [u64; 4] {
+    let q128 = _mm_loadu_si128(query as *const __m128i);
+    let q_bcast = _mm512_broadcast_i32x4(q128);
+    let r = _mm512_loadu_si512(records as *const __m512i);
+    let xor = _mm512_xor_si512(r, q_bcast);
+    let pop = _mm512_popcnt_epi8(xor);
+    // Each of the 8 qwords in `sad` holds the sum of eight per-byte popcounts.
+    // A 16-byte record spans two adjacent qwords, so pair-sum {0,1},{2,3},…
+    let sad = _mm512_sad_epu8(pop, _mm512_setzero_si512());
+    let mut buf = [0u64; 8];
+    _mm512_storeu_si512(buf.as_mut_ptr() as *mut __m512i, sad);
+    [
+        buf[0] + buf[1],
+        buf[2] + buf[3],
+        buf[4] + buf[5],
+        buf[6] + buf[7],
+    ]
+}
+
+/// Compute four Hamming distances (four 32-byte records vs one 32-byte query)
+/// in two AVX-512 passes.
+///
+/// Two 512-bit loads cover 128 bytes = four 32-byte records. The 32-byte query
+/// is broadcast to both halves of a ZMM via `_mm512_broadcast_i64x4`, then each
+/// half-vector XOR + VPOPCNTB + VPSADBW reduces to two per-record distances.
+///
+/// # Safety
+/// `records` must be valid for 128 readable bytes and `query` must be valid for
+/// 32 readable bytes. Caller must ensure the CPU supports the target features.
+#[inline]
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512bitalg")]
+unsafe fn hamming_distance_avx512_fixed4_w32(records: *const u8, query: *const u8) -> [u64; 4] {
+    let q256 = _mm256_loadu_si256(query as *const __m256i);
+    let q_bcast = _mm512_broadcast_i64x4(q256);
+    let zero = _mm512_setzero_si512();
+
+    let r01 = _mm512_loadu_si512(records as *const __m512i);
+    let r23 = _mm512_loadu_si512(records.add(64) as *const __m512i);
+
+    let sad01 = _mm512_sad_epu8(_mm512_popcnt_epi8(_mm512_xor_si512(r01, q_bcast)), zero);
+    let sad23 = _mm512_sad_epu8(_mm512_popcnt_epi8(_mm512_xor_si512(r23, q_bcast)), zero);
+
+    // Each 32-byte record spans four adjacent qwords in the SAD result.
+    let mut buf = [0u64; 8];
+    _mm512_storeu_si512(buf.as_mut_ptr() as *mut __m512i, sad01);
+    let d0 = buf[0] + buf[1] + buf[2] + buf[3];
+    let d1 = buf[4] + buf[5] + buf[6] + buf[7];
+    _mm512_storeu_si512(buf.as_mut_ptr() as *mut __m512i, sad23);
+    let d2 = buf[0] + buf[1] + buf[2] + buf[3];
+    let d3 = buf[4] + buf[5] + buf[6] + buf[7];
+    [d0, d1, d2, d3]
+}
+
+#[inline(always)]
+fn within_fixed_threshold(distance: u64, max_dist: i64) -> bool {
+    max_dist < 0 || distance <= max_dist as u64
+}
+
+// The per-width kernel wrappers below let the generic scanners stay free of
+// const generics and `if WIDTH == …` branches, matching the specialization
+// shape of the NEON scanners while giving LLVM straight-line code for each
+// width. Function pointers are captured statically in the ArrayScanner table.
+
+#[inline(always)]
+unsafe fn scan_batch4_w16(records: *const u8, query: *const u8) -> [u64; 4] {
+    hamming_distance_avx512_fixed4_w16(records, query)
+}
+#[inline(always)]
+unsafe fn scan_batch4_w32(records: *const u8, query: *const u8) -> [u64; 4] {
+    hamming_distance_avx512_fixed4_w32(records, query)
+}
+
+/// Generic scanner: find the first record index whose distance to `query` is
+/// within `max_dist`. Batches of four records per AVX-512 pass; scalar tail.
+///
+/// # Safety
+/// `big_array.len()` must be a multiple of `WIDTH`. Caller guarantees the CPU
+/// supports the target features.
+#[inline]
+unsafe fn array_first_avx512<const WIDTH: usize>(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+    batch4: unsafe fn(*const u8, *const u8) -> [u64; 4],
+    single: unsafe fn(*const u8, *const u8) -> u64,
+) -> Option<usize> {
+    let count = big_array.len() / WIDTH;
+    let mut index = 0;
+    let big_ptr = big_array.as_ptr();
+    let query_ptr = small_array.as_ptr();
+
+    while index + 4 <= count {
+        let distances = batch4(big_ptr.add(index * WIDTH), query_ptr);
+        for (lane, &distance) in distances.iter().enumerate() {
+            if within_fixed_threshold(distance, max_dist) {
+                return Some(index + lane);
+            }
+        }
+        index += 4;
+    }
+    while index < count {
+        let distance = single(big_ptr.add(index * WIDTH), query_ptr);
+        if within_fixed_threshold(distance, max_dist) {
+            return Some(index);
+        }
+        index += 1;
+    }
+    None
+}
+
+/// Generic scanner: find (distance, index) of the record closest to `query`
+/// within `max_dist`, breaking ties by lowest index. Short-circuits on exact
+/// match (distance == 0).
+///
+/// # Safety
+/// Same as `array_first_avx512`.
+#[inline]
+unsafe fn array_best_avx512<const WIDTH: usize>(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+    batch4: unsafe fn(*const u8, *const u8) -> [u64; 4],
+    single: unsafe fn(*const u8, *const u8) -> u64,
+) -> Option<(u64, usize)> {
+    let count = big_array.len() / WIDTH;
+    let mut best: Option<(u64, usize)> = None;
+    let mut index = 0;
+    let big_ptr = big_array.as_ptr();
+    let query_ptr = small_array.as_ptr();
+
+    while index + 4 <= count {
+        let distances = batch4(big_ptr.add(index * WIDTH), query_ptr);
+        for (lane, &distance) in distances.iter().enumerate() {
+            let candidate_index = index + lane;
+            let eligible = match best {
+                Some((best_distance, _)) => distance < best_distance,
+                None => within_fixed_threshold(distance, max_dist),
+            };
+            if !eligible {
+                continue;
+            }
+            if best.is_none() || distance < best.unwrap().0 {
+                best = Some((distance, candidate_index));
+                if distance == 0 {
+                    return best;
+                }
+            }
+        }
+        index += 4;
+    }
+
+    while index < count {
+        let distance = single(big_ptr.add(index * WIDTH), query_ptr);
+        let eligible = match best {
+            Some((best_distance, _)) => distance < best_distance,
+            None => within_fixed_threshold(distance, max_dist),
+        };
+        if eligible {
+            best = Some((distance, index));
+            if distance == 0 {
+                return best;
+            }
+        }
+        index += 1;
+    }
+    best
+}
+
+/// Generic scanner: collect all (distance, index) pairs in ascending-index
+/// order with `distance <= max_dist` (or all if `max_dist < 0`).
+///
+/// # Safety
+/// Same as `array_first_avx512`.
+#[inline]
+unsafe fn array_all_avx512<const WIDTH: usize>(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+    batch4: unsafe fn(*const u8, *const u8) -> [u64; 4],
+    single: unsafe fn(*const u8, *const u8) -> u64,
+) -> Vec<(u64, usize)> {
+    let count = big_array.len() / WIDTH;
+    let mut matches = Vec::new();
+    let mut index = 0;
+    let big_ptr = big_array.as_ptr();
+    let query_ptr = small_array.as_ptr();
+
+    while index + 4 <= count {
+        let distances = batch4(big_ptr.add(index * WIDTH), query_ptr);
+        for (lane, &distance) in distances.iter().enumerate() {
+            if within_fixed_threshold(distance, max_dist) {
+                matches.push((distance, index + lane));
+            }
+        }
+        index += 4;
+    }
+
+    while index < count {
+        let distance = single(big_ptr.add(index * WIDTH), query_ptr);
+        if within_fixed_threshold(distance, max_dist) {
+            matches.push((distance, index));
+        }
+        index += 1;
+    }
+    matches
+}
+
+// -----------------------------------------------------------------------------
+// Public (crate-visible) scanner entry points. `select_array_scanner_for_width`
+// captures these as function pointers, so the runtime feature check has already
+// happened at the point they are invoked.
+// -----------------------------------------------------------------------------
+
+/// # Safety
+/// Caller must ensure `avx512f + avx512bw + avx512bitalg` are available and
+/// that `big_array.len() % 16 == 0`.
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512bitalg")]
+pub(crate) unsafe fn array_first_avx512_16(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Option<usize> {
+    array_first_avx512::<16>(
+        big_array,
+        small_array,
+        max_dist,
+        scan_batch4_w16,
+        hamming_distance_avx512_fixed16,
+    )
+}
+
+/// # Safety
+/// Same as `array_first_avx512_16`.
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512bitalg")]
+pub(crate) unsafe fn array_best_avx512_16(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Option<(u64, usize)> {
+    array_best_avx512::<16>(
+        big_array,
+        small_array,
+        max_dist,
+        scan_batch4_w16,
+        hamming_distance_avx512_fixed16,
+    )
+}
+
+/// # Safety
+/// Same as `array_first_avx512_16`.
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512bitalg")]
+pub(crate) unsafe fn array_all_avx512_16(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Vec<(u64, usize)> {
+    array_all_avx512::<16>(
+        big_array,
+        small_array,
+        max_dist,
+        scan_batch4_w16,
+        hamming_distance_avx512_fixed16,
+    )
+}
+
+/// # Safety
+/// Caller must ensure `avx512f + avx512bw + avx512bitalg` are available and
+/// that `big_array.len() % 32 == 0`.
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512bitalg")]
+pub(crate) unsafe fn array_first_avx512_32(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Option<usize> {
+    array_first_avx512::<32>(
+        big_array,
+        small_array,
+        max_dist,
+        scan_batch4_w32,
+        hamming_distance_avx512_fixed32,
+    )
+}
+
+/// # Safety
+/// Same as `array_first_avx512_32`.
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512bitalg")]
+pub(crate) unsafe fn array_best_avx512_32(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Option<(u64, usize)> {
+    array_best_avx512::<32>(
+        big_array,
+        small_array,
+        max_dist,
+        scan_batch4_w32,
+        hamming_distance_avx512_fixed32,
+    )
+}
+
+/// # Safety
+/// Same as `array_first_avx512_32`.
+#[target_feature(enable = "avx512f", enable = "avx512bw", enable = "avx512bitalg")]
+pub(crate) unsafe fn array_all_avx512_32(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Vec<(u64, usize)> {
+    array_all_avx512::<32>(
+        big_array,
+        small_array,
+        max_dist,
+        scan_batch4_w32,
+        hamming_distance_avx512_fixed32,
+    )
+}
+
+// -----------------------------------------------------------------------------
+// Feature-checked trampolines used by the `ArrayScanner` function-pointer table
+// in `api.rs`. Function pointers cannot carry `#[target_feature]`, so these
+// safe wrappers re-check the feature at every call (cheap after the first
+// invocation because `is_x86_feature_detected!` caches the result).
+// -----------------------------------------------------------------------------
+
+#[inline]
+pub(crate) fn array_first_avx512_16_dispatch(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Option<usize> {
+    unsafe { array_first_avx512_16(big_array, small_array, max_dist) }
+}
+
+#[inline]
+pub(crate) fn array_best_avx512_16_dispatch(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Option<(u64, usize)> {
+    unsafe { array_best_avx512_16(big_array, small_array, max_dist) }
+}
+
+#[inline]
+pub(crate) fn array_all_avx512_16_dispatch(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Vec<(u64, usize)> {
+    unsafe { array_all_avx512_16(big_array, small_array, max_dist) }
+}
+
+#[inline]
+pub(crate) fn array_first_avx512_32_dispatch(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Option<usize> {
+    unsafe { array_first_avx512_32(big_array, small_array, max_dist) }
+}
+
+#[inline]
+pub(crate) fn array_best_avx512_32_dispatch(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Option<(u64, usize)> {
+    unsafe { array_best_avx512_32(big_array, small_array, max_dist) }
+}
+
+#[inline]
+pub(crate) fn array_all_avx512_32_dispatch(
+    big_array: &[u8],
+    small_array: &[u8],
+    max_dist: i64,
+) -> Vec<(u64, usize)> {
+    unsafe { array_all_avx512_32(big_array, small_array, max_dist) }
+}
+
 /// Scalar fallback for hex string distance with max_dist.
 #[inline]
 unsafe fn hamming_distance_string_classic_with_max(
@@ -1344,5 +1796,216 @@ mod tests {
                 );
             }
         }
+    }
+
+    fn avx512_scanner_hw_available() -> bool {
+        is_x86_feature_detected!("avx512f")
+            && is_x86_feature_detected!("avx512bw")
+            && is_x86_feature_detected!("avx512bitalg")
+    }
+
+    fn scalar_byte_distance(a: &[u8], b: &[u8]) -> u64 {
+        a.iter()
+            .zip(b.iter())
+            .map(|(x, y)| (x ^ y).count_ones() as u64)
+            .sum()
+    }
+
+    // Deterministic PRNG so the batched-vs-scalar comparisons stay
+    // reproducible when this test runs on real AVX-512 hardware.
+    struct SplitMix {
+        state: u64,
+    }
+    impl SplitMix {
+        fn new(seed: u64) -> Self {
+            Self { state: seed }
+        }
+        fn next(&mut self) -> u8 {
+            self.state = self.state.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = self.state;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            ((z ^ (z >> 31)) >> 56) as u8
+        }
+        fn vec(&mut self, n: usize) -> Vec<u8> {
+            (0..n).map(|_| self.next()).collect()
+        }
+    }
+
+    fn oracle_first_best_all(
+        big: &[u8],
+        small: &[u8],
+        max_dist: i64,
+    ) -> (Option<usize>, Option<(u64, usize)>, Vec<(u64, usize)>) {
+        let mut first = None;
+        let mut best: Option<(u64, usize)> = None;
+        let mut all = Vec::new();
+        for (i, record) in big.chunks_exact(small.len()).enumerate() {
+            let d = scalar_byte_distance(record, small);
+            if max_dist >= 0 && d > max_dist as u64 {
+                continue;
+            }
+            if first.is_none() {
+                first = Some(i);
+            }
+            best = match best {
+                Some((bd, bi)) if bd < d || (bd == d && bi < i) => Some((bd, bi)),
+                _ => Some((d, i)),
+            };
+            all.push((d, i));
+        }
+        (first, best, all)
+    }
+
+    // Batch-of-four kernel produces the same per-record distances as a scalar
+    // popcount. Exercises the pair-sum reduction of adjacent SAD qwords.
+    #[test]
+    fn avx512_fixed4_w16_matches_scalar() {
+        if !avx512_scanner_hw_available() {
+            return;
+        }
+        let mut rng = SplitMix::new(0xC0FFEE_D15EA5E);
+        for _ in 0..8 {
+            let records = rng.vec(64);
+            let query = rng.vec(16);
+            let expected = [
+                scalar_byte_distance(&records[0..16], &query),
+                scalar_byte_distance(&records[16..32], &query),
+                scalar_byte_distance(&records[32..48], &query),
+                scalar_byte_distance(&records[48..64], &query),
+            ];
+            let actual =
+                unsafe { hamming_distance_avx512_fixed4_w16(records.as_ptr(), query.as_ptr()) };
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn avx512_fixed4_w32_matches_scalar() {
+        if !avx512_scanner_hw_available() {
+            return;
+        }
+        let mut rng = SplitMix::new(0xDEADBEEF_FEEDFACE);
+        for _ in 0..8 {
+            let records = rng.vec(128);
+            let query = rng.vec(32);
+            let expected = [
+                scalar_byte_distance(&records[0..32], &query),
+                scalar_byte_distance(&records[32..64], &query),
+                scalar_byte_distance(&records[64..96], &query),
+                scalar_byte_distance(&records[96..128], &query),
+            ];
+            let actual =
+                unsafe { hamming_distance_avx512_fixed4_w32(records.as_ptr(), query.as_ptr()) };
+            assert_eq!(actual, expected);
+        }
+    }
+
+    // Full-scanner semantic parity for widths 16 and 32 across a matrix of
+    // catalog sizes (including sizes not divisible by four to exercise the
+    // scalar tail) and thresholds (first/best/all ordering, ties, exact match
+    // short-circuit, and the `max_dist < 0` catch-all path).
+    fn assert_scanners_match_oracle(width: usize, count: usize, seed: u64) {
+        let mut rng = SplitMix::new(seed);
+        let small = rng.vec(width);
+        let mut big = rng.vec(count * width);
+
+        // Seed multiple exact-match records to test lowest-index tie behavior,
+        // and one near-match record to give us threshold cases.
+        let match_indices = if count >= 8 {
+            vec![1usize, count / 2, count - 1]
+        } else {
+            vec![0usize.min(count.saturating_sub(1))]
+        };
+        for &idx in &match_indices {
+            let record = &mut big[idx * width..(idx + 1) * width];
+            record.copy_from_slice(&small);
+        }
+        if count >= 4 {
+            let near = count / 3;
+            big[near * width..(near + 1) * width].copy_from_slice(&small);
+            big[near * width] ^= 0xF0;
+        }
+
+        for &max_dist in &[-1i64, 0, 3, 4, 5, 8, 128] {
+            let (efirst, ebest, eall) = oracle_first_best_all(&big, &small, max_dist);
+
+            let (afirst, abest, aall) = if width == 16 {
+                (
+                    unsafe { array_first_avx512_16(&big, &small, max_dist) },
+                    unsafe { array_best_avx512_16(&big, &small, max_dist) },
+                    unsafe { array_all_avx512_16(&big, &small, max_dist) },
+                )
+            } else {
+                (
+                    unsafe { array_first_avx512_32(&big, &small, max_dist) },
+                    unsafe { array_best_avx512_32(&big, &small, max_dist) },
+                    unsafe { array_all_avx512_32(&big, &small, max_dist) },
+                )
+            };
+            assert_eq!(
+                afirst, efirst,
+                "first mismatch width={width} count={count} max_dist={max_dist}"
+            );
+            assert_eq!(
+                abest, ebest,
+                "best mismatch width={width} count={count} max_dist={max_dist}"
+            );
+            assert_eq!(
+                aall, eall,
+                "all mismatch width={width} count={count} max_dist={max_dist}"
+            );
+        }
+    }
+
+    #[test]
+    fn avx512_scanners_w16_random_oracle_various_counts() {
+        if !avx512_scanner_hw_available() {
+            return;
+        }
+        // Counts include values just below/at/above a batch of 4 to exercise
+        // the batch/tail boundary, plus a larger catalog.
+        for &count in &[1usize, 3, 4, 5, 7, 8, 15, 33, 64, 512] {
+            assert_scanners_match_oracle(16, count, 0x1234_5678 ^ count as u64);
+        }
+    }
+
+    #[test]
+    fn avx512_scanners_w32_random_oracle_various_counts() {
+        if !avx512_scanner_hw_available() {
+            return;
+        }
+        for &count in &[1usize, 3, 4, 5, 7, 8, 15, 33, 64, 512] {
+            assert_scanners_match_oracle(32, count, 0xCAFEBABE ^ count as u64);
+        }
+    }
+
+    // `best` must return the lowest index among ties and short-circuit on
+    // an exact match (distance == 0). Include a first-record exact match
+    // followed by later exact matches to guarantee both conditions.
+    #[test]
+    fn avx512_scanner_best_preserves_lowest_index_tie() {
+        if !avx512_scanner_hw_available() {
+            return;
+        }
+        let width = 16usize;
+        let small = vec![0x5Au8; width];
+        let count = 20usize;
+        let mut big = vec![0xA5u8; count * width];
+        for &i in &[3usize, 3, 7, 13] {
+            big[i * width..(i + 1) * width].copy_from_slice(&small);
+        }
+        // Two records with distance == 1 by flipping one bit.
+        for &i in &[5usize, 15] {
+            big[i * width..(i + 1) * width].copy_from_slice(&small);
+            big[i * width] ^= 0x01;
+        }
+        assert_eq!(unsafe { array_first_avx512_16(&big, &small, -1) }, Some(3));
+        assert_eq!(
+            unsafe { array_best_avx512_16(&big, &small, -1) },
+            Some((0, 3))
+        );
+        let all = unsafe { array_all_avx512_16(&big, &small, 1) };
+        assert_eq!(all, vec![(0, 3), (1, 5), (0, 7), (0, 13), (1, 15)]);
     }
 }

--- a/src/x86_simd.rs
+++ b/src/x86_simd.rs
@@ -1997,8 +1997,8 @@ mod tests {
     }
 
     // `best` must return the lowest index among ties and short-circuit on
-    // an exact match (distance == 0). Include a first-record exact match
-    // followed by later exact matches to guarantee both conditions.
+    // an exact match (distance == 0). Include several exact matches to
+    // guarantee both conditions.
     #[test]
     fn avx512_scanner_best_preserves_lowest_index_tie() {
         if !avx512_scanner_hw_available() {
@@ -2016,7 +2016,7 @@ mod tests {
             big[i * width..(i + 1) * width].copy_from_slice(&small);
             big[i * width] ^= 0x01;
         }
-        assert_eq!(unsafe { array_first_avx512_16(&big, &small, -1) }, Some(3));
+        assert_eq!(unsafe { array_first_avx512_16(&big, &small, 0) }, Some(3));
         assert_eq!(
             unsafe { array_best_avx512_16(&big, &small, -1) },
             Some((0, 3))

--- a/src/x86_simd.rs
+++ b/src/x86_simd.rs
@@ -637,10 +637,6 @@ pub unsafe fn hamming_distance_bytes_avx512(a: &[u8], b: &[u8], max_dist: i64) -
     let length = a.len();
     let mut i = 0;
 
-    if length < 64 {
-        return hamming_distance_bytes_avx2(a, b, max_dist);
-    }
-
     let zero = _mm512_setzero_si512();
 
     if max_dist < 0 {
@@ -1319,4 +1315,34 @@ unsafe fn hamming_distance_string_classic_with_max(
         i += 1;
     }
     Ok(difference)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn avx512_masked_byte_inputs_match_scalar_results() {
+        if !is_x86_feature_detected!("avx512bw") || !is_x86_feature_detected!("avx512bitalg") {
+            return;
+        }
+
+        for length in [1usize, 7, 8, 15, 16, 31, 32, 48, 63] {
+            let a = vec![0xFF; length];
+            let b = vec![0x00; length];
+            let expected = (length * 8) as u64;
+
+            unsafe {
+                assert_eq!(hamming_distance_bytes_avx512(&a, &b, -1), expected);
+                assert_eq!(
+                    hamming_distance_bytes_avx512(&a, &b, expected as i64),
+                    expected
+                );
+                assert_eq!(
+                    hamming_distance_bytes_avx512(&a, &b, expected as i64 - 1),
+                    u64::MAX
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What

Improves the AVX-512 BITALG paths identified in #51 and adds a repeatable three-run x86 benchmark harness.

- Uses the existing masked AVX-512 tail implementation for byte inputs below 64 bytes instead of falling back through AVX2/SSE.
- Adds AVX-512 cross-record scanners for 16- and 32-byte catalogs, processing four records per batch.
- Preserves first-index ordering, lowest-index best ties, ordered all-results, threshold semantics, exact-match termination, and scalar tails.
- Keeps explicit classic/SSE/AVX2 selections unchanged; the new scanners engage only for `native` or `avx512` when AVX-512 BITALG is available.
- Expands the x86 threshold and scanner benchmark matrices.

Advances the AVX-512 portion of #51. AVX2-only tuning remains a separately measured follow-up.

## Performance

Three-run medians on a Google Cloud `c4-standard-4`, Intel Xeon Platinum 8581C (Emerald Rapids), with `avx2`, `avx512bw`, and `avx512_bitalg` exposed.

### Python fixed-width scans

| Workload | Before | After | Speedup |
|---|---:|---:|---:|
| 1024x16 first, random/no-match | 3.222 us | 0.679 us | 4.75x |
| 1024x16 best, random/no-match | 3.720 us | 0.651 us | 5.72x |
| 1024x16 all, random/no-match | 3.466 us | 0.710 us | 4.88x |
| 1024x32 first, random/no-match | 3.199 us | 1.278 us | 2.50x |
| 1024x32 best, random/no-match | 3.729 us | 1.383 us | 2.70x |
| 1024x32 all, random/no-match | 3.445 us | 1.377 us | 2.50x |

### Short AVX-512 byte inputs

| Bytes | Before | After | Improvement |
|---:|---:|---:|---:|
| 16 | 5.380 ns | 4.048 ns | 32.9% |
| 32 | 6.112 ns | 4.068 ns | 50.2% |
| 48 | 6.924 ns | 4.071 ns | 70.1% |
| 63 | 11.955 ns | 4.068 ns | 193.9% |

The hybrid scanner scalar-checks the first record before batching. The accepted worst-case trade-off is approximately 0.5-0.6 ns for 16-byte `first`/`best` when an exact match is at index 0; full scans improve by 2.77x-4.07x in Rust and 2.50x-5.72x through Python.

## Testing

- `cargo test --lib --no-default-features` on the AVX-512 C4 VM — 72 tests
- `cargo test --no-default-features` on ARM64 — 76 unit and 2 doc tests
- `python -m pytest test/ -k "not bench"` — 80 passed, 3 skipped
- x86 benchmark comparisons use three-run medians on the same VM
- Independent correctness and safety review found no scanner defects
- `cargo fmt --check`
- `git diff --check`
